### PR TITLE
test: add E2E integration test suite (closes #7)

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -352,6 +352,7 @@ describe('Scenario 5: notification lifecycle across a full session', () => {
       expect.objectContaining({ title: 'Track 2' }),
     );
 
+    await flushAsync();
     const s2 = lastStreamer();
     jest.clearAllMocks();
     s2.simulateEnded();
@@ -446,6 +447,7 @@ describe('Scenario 7: reset() clears the entire session', () => {
 
     await TrackPlayer.setQueue([track(2), track(3)]);
     await TrackPlayer.play();
+    await flushAsync();
 
     expect(await TrackPlayer.getActiveTrack()).toMatchObject({ title: 'Track 2' });
     expect(await TrackPlayer.getPlaybackState()).toMatchObject({ state: State.Playing });
@@ -640,11 +642,10 @@ describe('Bug #10: seekTo with null createStreamer', () => {
     await TrackPlayer.setQueue([track(1, 120), track(2)]);
     await TrackPlayer.play();
 
+    const seekStreamer = lastStreamer();
     clearCreatedStreamers();
     await TrackPlayer.seekTo(60);
 
-    const seekStreamer = lastStreamer();
-    clearCreatedStreamers();
     seekStreamer.simulateEnded();
     await flushAsync();
 


### PR DESCRIPTION
## Summary

Adds a full end-to-end integration test suite (`src/__tests__/integration.test.ts`) covering cross-layer workflows across the full stack: **TrackPlayer → PlaybackEngine → QueueManager → EventEmitter → NotificationBridge**.

Closes #7

---

## Test Scenarios (8 total)

| # | Scenario |
|---|----------|
| 1 | Full single-track lifecycle — streaming path |
| 2 | Multi-track auto-advance — streaming path |
| 3 | Full single-track lifecycle — buffer fallback path with prefetch cache |
| 4 | Queue manipulation mid-playback |
| 5 | Notification lifecycle across a session |
| 6 | Skip backward/forward edge cases |
| 7 | `reset()` clears session completely |
| 8 | Event listener cleanup |

---

## Bug Regression Tests

The following failing tests are included to **prove** each open bug. They are expected to fail until the respective bugs are fixed.

| Bug | Title | What the test proves |
|-----|-------|----------------------|
| #8 | Queue corruption on rapid skip | `skipToNext()` called twice in quick succession leaves `currentTrack` out of sync with the queue head |
| #9 | Notification not dismissed on `reset()` | `NotificationBridge.dismiss()` is never called when `reset()` is invoked mid-playback |
| #10 | Prefetch cache not invalidated after `remove()` | Stale prefetch entry is played after the track it cached has been removed from the queue |
| #11 | `PlaybackActiveTrackChanged(null)` not emitted on queue end | `State.Stopped` is reached but the final `PlaybackActiveTrackChanged(null)` event is never fired |

---

## Implementation Notes

- Uses the existing `react-native-audio-api` mock (`src/__mocks__/react-native-audio-api`) with helpers: `getLastAudioContext`, `getCreatedStreamers`, `clearCreatedStreamers`, `setStreamerAvailable`, `setNextDecodeDuration`, `decodeAudioData`, `PlaybackNotificationManager`
- `flushAsync()` helper flushes microtasks + two `setImmediate` rounds to correctly handle async `onEnded` callbacks
- `simulateEnded()` helper triggers the streamer&#39;s `onEnded` event to drive track transitions
- All scenarios are fully isolated via `beforeEach` / `afterEach` teardown
