### PR TITLE
fix: emit PlaybackActiveTrackChanged(null) and stop engine at end of queue

### DIFF
--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -43,8 +43,16 @@ engine.onTrackEnded(async () => {
       engine.prefetchNext(upcoming).catch(() => { /* non-fatal */ });
     }
   } else {
-    // Reached end of queue
+    // Reached end of queue — reset engine to Stopped and notify listeners so
+    // useProgress stops polling and active-track consumers see null.
+    await engine.stop();
     await bridge.hide();
+    emitter.emit(Event.PlaybackActiveTrackChanged, {
+      track: null,
+      index: -1,
+      lastTrack,
+      lastIndex,
+    });
   }
 });
 


### PR DESCRIPTION
Closes #11

## Problem

After the last track in the queue ends naturally:
- Engine state remained `State.Ended` instead of transitioning to `State.Stopped`
- `queue.getActiveTrack()` still returned the last track (non-null)
- `Event.PlaybackActiveTrackChanged({ track: null, index: -1 })` was never emitted
- `useProgress` kept polling indefinitely because state never reached `Stopped`

## Fix

In the `engine.onTrackEnded` callback, the `else` branch (reached end of queue) now:
1. Calls `engine.stop()` to transition state from `State.Ended` → `State.Stopped`
2. Calls `bridge.hide()` to dismiss the notification (existing behaviour, unchanged)
3. Emits `Event.PlaybackActiveTrackChanged` with `{ track: null, index: -1, lastTrack, lastIndex }` so consumers know the active track is gone

This mirrors exactly what `TrackPlayer.stop()` does when called manually, making end-of-queue behave consistently with an explicit stop.

## Diff summary

```
src/TrackPlayer.ts  +7 lines  (else branch of onTrackEnded)
  - // Reached end of queue
  + // Reached end of queue — reset engine to Stopped and notify listeners
  + await engine.stop();
    await bridge.hide();
  + emitter.emit(Event.PlaybackActiveTrackChanged, {
  +   track: null, index: -1, lastTrack, lastIndex,
  + });
```