### PR TITLE
feat: add ESLint and Prettier configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  "env": {
+    "node": true,
+    "jest": true
+  },
+  "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error"
+  },
+  "ignorePatterns": ["dist", "coverage", "node_modules", "*.config.js"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+*.lock
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "prepare": "tsup",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "lint": "eslint src --ext .ts,.tsx",
+    "lint:fix": "eslint src --ext .ts,.tsx --fix",
+    "format": "prettier --write \"src/**/*.{ts,tsx,json,md}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,json,md}\""
   },
   "keywords": [
     "react-native",
@@ -60,7 +64,11 @@
     "@expo/config-plugins": ">=8.0.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.0",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "eslint": "^8.57.0",
     "jest": "^30.2.0",
+    "prettier": "^3.2.5",
     "react": "^19.2.4",
     "react-native": "^0.84.1",
     "react-native-audio-api": "^0.11.6",


### PR DESCRIPTION
Adds linting via ESLint with TypeScript support and code formatting via Prettier.

## Changes
- Added ESLint with @typescript-eslint plugins
- Added Prettier for consistent code formatting
- Added npm scripts: lint, lint:fix, format, format:check
- Created .eslintrc.json, .prettierrc.json, .prettierignore config files

## Configuration
- ESLint: TypeScript strict mode, no-floating-promises, no-unused-vars, no-shadow rules
- Prettier: 100 char width, 2-space indent, single quotes, trailing commas, LF line endings

## Usage
- `npm run lint` — check for linting errors
- `npm run lint:fix` — auto-fix linting errors
- `npm run format` — auto-format code
- `npm run format:check` — check formatting

Note: These are available as manual checks. Enforcement in CI can be added in a future PR.