### PR TITLE
remove unused collectStates() helper from PlaybackEngine.test.ts

### DIFF
--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -30,17 +30,6 @@ function makeEngine(): PlaybackEngine {
   return engine;
 }
 
-function collectStates(engine: PlaybackEngine): State[] {
-  const states: State[] = [];
-  // Access the internal emitter via the module-level singleton
-  // by listening on the 'playback-state' event.
-  const { emitter } = jest.requireMock('../EventEmitter') as {
-    emitter: { on: (e: string, h: (...a: unknown[]) => void) => () => void };
-  };
-  // We actually import the real emitter, not a mock — use it directly.
-  return states;
-}
-
 // ---------------------------------------------------------------------------
 // Reset per test
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the `collectStates()` helper function (lines 33–42) from `src/__tests__/PlaybackEngine.test.ts`
- The function was defined but never called anywhere in the test file — dead code cleanup
- The `State` import is retained as it is used extensively throughout the rest of the test suite

## Test plan

- [ ] Verify existing tests still pass (`npm test` / `jest`)
- [ ] Confirm no references to `collectStates` remain in the codebase

👾 Generated with [Letta Code](https://letta.com)