### PR TITLE
chore: remove react-native-track-player references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # react-native-track-playback
 
-A drop-in replacement for [react-native-track-player](https://github.com/doublesymmetry/react-native-track-player) built on top of [react-native-audio-api](https://github.com/software-mansion/react-native-audio-api).
+A React Native audio playback library built on [react-native-audio-api](https://github.com/software-mansion/react-native-audio-api).
 
 ## Overview
 
-This library provides the same API surface as `react-native-track-player`, allowing you to migrate seamlessly while leveraging the modern `react-native-audio-api` for audio playback.
+This library provides queue-based audio playback with lock screen and notification controls, leveraging `react-native-audio-api` for audio output.
 
 **Key Features:**
 
@@ -185,34 +185,6 @@ enum State {
   Error = 'error',
 }
 ```
-
-## Migration from react-native-track-player
-
-This library is designed as a drop-in replacement. In most cases, you only need to change the import:
-
-```diff
-- import TrackPlayer, { State, Event } from 'react-native-track-player';
-+ import TrackPlayer, { State, Event } from 'react-native-track-playback';
-```
-
-### Key Differences
-
-1. **No `setupPlayer()` call required** - The player initializes automatically on first use.
-
-2. **`registerPlaybackService()` is a no-op** - Included for compatibility but does nothing. Remote events are handled automatically.
-
-3. **Capabilities** - The `Capability` enum is exported for compatibility, but capabilities are enabled by default and don't need to be configured.
-
-4. **Track properties** - The core properties (`id`, `url`, `title`, `artist`, `artwork`, `duration`) are supported. Some advanced properties from RNTP may not be available.
-
-### Migration Checklist
-
-- [ ] Update imports from `react-native-track-player` to `react-native-track-playback`
-- [ ] Remove `setupPlayer()` calls (or keep them - they're no-ops for compatibility)
-- [ ] Remove `registerPlaybackService()` wrapper (or keep it - it's a no-op)
-- [ ] Remove capability configuration (or keep it - it's ignored)
-- [ ] Update Expo config plugin if applicable
-- [ ] Test playback, queue management, and lock screen controls
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-track-playback",
   "version": "0.1.0",
-  "description": "A drop-in replacement for react-native-track-player built on react-native-audio-api",
+  "description": "A React Native audio playback library built on react-native-audio-api",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -37,16 +37,10 @@
     "audio",
     "music",
     "player",
-    "track-player",
     "expo"
   ],
   "license": "MIT",
   "expo": {
-    "install": {
-      "exclude": [
-        "react-native-track-player"
-      ]
-    },
     "plugin": "./plugin/index.js"
   },
   "peerDependencies": {

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -4,7 +4,7 @@ import { emitter } from './EventEmitter';
 
 /**
  * Maps react-native-audio-api's PlaybackNotificationManager events to the
- * RNTP-style Event.* callbacks that consumers register via addEventListener().
+ * Event.* callbacks that consumers register via addEventListener().
  *
  * Also handles updating the lock screen / notification metadata whenever
  * the active track or playback state changes.
@@ -63,7 +63,7 @@ export class NotificationBridge {
       })
     );
 
-    // Wire RNAP notification events → package EventEmitter (RNTP Event.* shape)
+    // Wire RNAP notification events → package EventEmitter
     this.subscriptions = [
       PlaybackNotificationManager.addEventListener(
         'playbackNotificationPlay',

--- a/src/QueueManager.ts
+++ b/src/QueueManager.ts
@@ -29,7 +29,6 @@ export class QueueManager {
   /**
    * Remove tracks by index or Track object (single or array).
    * When Track objects are passed, they are resolved to indices by URL.
-   * Mirrors the RNTP remove() signature.
    * Adjusts currentIndex after removal — if the current track was removed,
    * clamps to the new last index.
    */

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -7,7 +7,6 @@ import { _registerProgressGetters } from './hooks/useProgress';
 
 // ---------------------------------------------------------------------------
 // Module-level singletons
-// All state lives here so TrackPlayer can be used as a static API (matching RNTP).
 // ---------------------------------------------------------------------------
 
 const queue = new QueueManager();
@@ -68,8 +67,7 @@ const TrackPlayer = {
 
   /**
    * Initialize the audio engine and register progress getters for useProgress().
-   * Must be called before any other TrackPlayer method — equivalent to RNTP's
-   * setupPlayer().
+   * Must be called before any other TrackPlayer method.
    */
   async setupPlayer(): Promise<void> {
     engine.init();
@@ -100,10 +98,9 @@ const TrackPlayer = {
 
   /**
    * Configure playback capabilities (controls shown in the system notification).
-   * Equivalent to RNTP's updateOptions().
    */
   async updateOptions(options: UpdateOptions): Promise<void> {
-    const caps = options.capabilities ?? options.notificationCapabilities ?? [];
+    const caps = options.capabilities ?? [];
     await bridge.setup(caps);
   },
 
@@ -113,7 +110,7 @@ const TrackPlayer = {
 
   /**
    * Register a listener for a TrackPlayer event.
-   * Returns a subscription object with a `.remove()` method — identical to RNTP.
+   * Returns a subscription object with a `.remove()` method.
    */
   addEventListener(
     event: Event,
@@ -128,16 +125,13 @@ const TrackPlayer = {
   // --------------------------------------------------------------------------
 
   /**
-   * Replace the current queue without starting playback — matches RNTP semantics
-   * exactly. The caller must explicitly invoke play() to begin audio.
+   * Replace the current queue without starting playback. The caller must
+   * explicitly invoke play() to begin audio.
    *
    * Always stops the engine before replacing the queue. This handles all states:
    * - Playing / Paused: tears down the active source node
    * - Loading / Buffering: increments loadGeneration to cancel the in-flight load
    * - Stopped / Ended / None: no-op on audio state, just resets cleanly
-   *
-   * We deliberately do NOT call loadAndPlay() here so that setQueue() followed
-   * by play() behaves identically to RNTP — i.e. the app controls when audio starts.
    */
   async setQueue(tracks: Track[]): Promise<void> {
     await engine.stop();
@@ -151,8 +145,7 @@ const TrackPlayer = {
 
   /**
    * Remove tracks by index or Track object (single or array).
-   * Matches RNTP's remove() signature — also accepts Track objects for
-   * convenience (resolved to indices by URL).
+   * Also accepts Track objects for convenience (resolved to indices by URL).
    */
   async remove(indexOrIndices: number | number[] | Track | Track[]): Promise<void> {
     queue.remove(indexOrIndices);
@@ -180,7 +173,6 @@ const TrackPlayer = {
    * and lock screen are updated immediately.
    *
    * `url` cannot be changed here — use setQueue() or add() for that.
-   * Mirrors RNTP's updateMetadataForTrack().
    */
   async updateMetadataForTrack(index: number, metadata: TrackMetadata): Promise<void> {
     const updated = queue.updateTrack(index, metadata);
@@ -200,7 +192,6 @@ const TrackPlayer = {
    *
    * Use this for ephemeral display updates (e.g. artwork arriving late, live
    * stream title changes) without permanently altering the queued track data.
-   * Mirrors RNTP's updateNowPlayingMetadata().
    */
   async updateNowPlayingMetadata(metadata: TrackMetadata): Promise<void> {
     const track = queue.getActiveTrack();
@@ -321,7 +312,7 @@ const TrackPlayer = {
 
   /**
    * If more than 3 seconds into the current track, seek back to the start.
-   * Otherwise, go to the previous track. Matches RNTP's skipToPrevious() behaviour.
+   * Otherwise, go to the previous track.
    */
   async skipToPrevious(): Promise<void> {
     const position = engine.getPosition();
@@ -371,17 +362,10 @@ const TrackPlayer = {
   // State queries
   // --------------------------------------------------------------------------
 
-  /**
-   * Modern RNTP API — returns { state: State }.
-   */
   async getPlaybackState(): Promise<PlaybackState> {
     return { state: engine.getState() };
   },
 
-  /**
-   * Legacy RNTP API — returns State directly.
-   * Kept for full drop-in compatibility.
-   */
   async getState(): Promise<State> {
     return engine.getState();
   },
@@ -405,20 +389,3 @@ const TrackPlayer = {
 };
 
 export default TrackPlayer;
-
-// ---------------------------------------------------------------------------
-// registerPlaybackService — no-op for drop-in compatibility
-// ---------------------------------------------------------------------------
-
-/**
- * In RNTP, this registers a background service function that handles remote
- * events. In react-native-track-playback, remote events are handled directly
- * via PlaybackNotificationManager, so no background service is needed.
- *
- * This function exists purely so that callers don't have to remove it during
- * migration. The passed factory is never invoked.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function registerPlaybackService(_factory: () => Promise<void>): void {
-  // intentional no-op
-}

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -115,7 +115,7 @@ describe('setQueue', () => {
     expect(active?.url).toBe('http://example.com/track1.mp3');
   });
 
-  it('does NOT emit PlaybackActiveTrackChanged (matches RNTP behaviour)', async () => {
+  it('does NOT emit PlaybackActiveTrackChanged', async () => {
     await setup();
     const handler = jest.fn();
     TrackPlayer.addEventListener(Event.PlaybackActiveTrackChanged, handler);

--- a/src/hooks/usePlaybackState.ts
+++ b/src/hooks/usePlaybackState.ts
@@ -3,11 +3,8 @@ import { State, PlaybackState, Event } from '../types';
 import { emitter } from '../EventEmitter';
 
 /**
- * Drop-in replacement for RNTP's usePlaybackState().
- *
  * Returns `{ state: State | undefined }`.
- * `state` is undefined until the first playback state event fires (i.e. before
- * TrackPlayer.setupPlayer() is called), matching RNTP's initial behaviour.
+ * `state` is undefined until the first playback state event fires.
  */
 export function usePlaybackState(): { state: State | undefined } {
   const [state, setState] = useState<State | undefined>(undefined);

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -3,8 +3,6 @@ import { Progress, State, Event, ActiveTrackChangedEvent } from '../types';
 import { emitter } from '../EventEmitter';
 
 /**
- * Drop-in replacement for RNTP's useProgress(updateInterval?).
- *
  * Polls position/duration from the engine on an interval.
  * Returns { position, duration, buffered } — all in seconds.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
 /**
  * react-native-track-playback
  *
- * Drop-in replacement for react-native-track-player, built on react-native-audio-api.
+ * A React Native audio playback library built on react-native-audio-api.
  *
  * Usage:
  *   import TrackPlayer, { State, Event, Capability, usePlaybackState, useProgress }
  *     from 'react-native-track-playback';
  */
 
-// Default export — the static TrackPlayer API (mirrors RNTP's default export)
+// Default export — the static TrackPlayer API
 export { default } from './TrackPlayer';
 
-// Named exports — mirrors RNTP's named exports
-export { registerPlaybackService } from './TrackPlayer';
+// Named exports
+
 
 // Types & enums
 export type { Track, TrackMetadata, PlaybackState, Progress, UpdateOptions, ActiveTrackChangedEvent } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface Track {
   genre?: string;
   artwork?: string;
   duration?: number;
-  // Open-ended: allow any extra fields callers pass through (matches RNTP behaviour)
+  // Open-ended: allow any extra fields callers pass through
   [key: string]: unknown;
 }
 
@@ -14,7 +14,6 @@ export interface Track {
  * Patchable metadata fields on a Track — everything except `url`.
  * Used by updateMetadataForTrack() and updateNowPlayingMetadata() to update
  * track info after the track has already been queued (e.g. artwork arriving late).
- * Mirrors RNTP's TrackMetadataBase type.
  */
 export type TrackMetadata = Omit<Track, 'url'>;
 
@@ -71,5 +70,4 @@ export interface ActiveTrackChangedEvent {
 
 export interface UpdateOptions {
   capabilities?: Capability[];
-  notificationCapabilities?: Capability[];
 }


### PR DESCRIPTION
Repositions the library as a standalone audio playback library rather than a drop-in RNTP replacement. Removes the registerPlaybackService no-op shim, simplifies UpdateOptions (drops notificationCapabilities), clears all RNTP references from comments, docs, and package metadata.