### PR TITLE
fix: align playStartOffset with Math.floor on streamer seek

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -359,7 +359,9 @@ export class PlaybackEngine {
       streamer.start(0);
 
       this.playStartContextTime = this.context!.currentTime;
-      this.playStartOffset = seconds;
+      // Use Math.floor to match the integer offset sent in the timeOffset URL param.
+      // Without this, the position formula drifts by up to 1s after a streamer seek.
+      this.playStartOffset = Math.floor(seconds);
       this.streamerNode = streamer;
       this.startStreamerEndedPoller(streamer);
     } else {
@@ -569,3 +571,4 @@ export class PlaybackEngine {
     }
   }
 }
+


### PR DESCRIPTION
Closes #52.

## Problem

`seekTo()` passes `Math.floor(seconds)` to the `timeOffset` URL parameter but sets `playStartOffset = seconds` (the raw float). The position formula then drifts by up to 1 second after a streamer seek because the streamer starts at the floored position while the formula uses the float offset.

## Fix

```ts
// Before
this.playStartOffset = seconds;

// After
this.playStartOffset = Math.floor(seconds);
```

One line change — `playStartOffset` now matches the integer offset actually sent to the streamer.