### PR TITLE
fix: reduce StreamerNode end-detection epsilon from 0.5s to 0.1s

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -455,7 +455,7 @@ export class PlaybackEngine {
         this.clearStreamerEndedPoller();
         return;
       }
-      const epsilon = 0.5;
+      const epsilon = 0.1;
       if (this.getPosition() >= this.currentTrackDuration - epsilon) {
         this.clearStreamerEndedPoller();
         this.setState(State.Ended);

--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -432,7 +432,7 @@ describe('onTrackEnded callback', () => {
 
     await engine.loadAndPlay(makeTrack(1, 30));
     const ctx = getLastAudioContext()!;
-    ctx.advanceTime(30); // position >= duration - 0.5 → triggers poller
+    ctx.advanceTime(30); // position >= duration - 0.1 → triggers poller
     jest.advanceTimersByTime(250);
 
     expect(cb).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Closes #51

Tightens the end-detection window in the `startStreamerEndedPoller` from **0.5 s to 0.1 s**.

The 500 ms window was overly generous and caused the engine to declare a track ended up to half a second before the audio actually finished, leading to premature next-track transitions.

A 100 ms window is still large enough to absorb real-world timer jitter (the poller fires every 250 ms) while eliminating the audible early-end artefact.

### Changes
- `src/PlaybackEngine.ts`: `epsilon = 0.5` → `epsilon = 0.1`
- `src/__tests__/PlaybackEngine.test.ts`: update comment to reflect new value