### PR TITLE
feat!: remove dead Capability.Stop and Event.RemoteStop

### DIFF
--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -14,7 +14,6 @@ import { emitter } from './EventEmitter';
 const CAPABILITY_TO_CONTROL: Partial<Record<Capability, string>> = {
   [Capability.Play]:           'play',
   [Capability.Pause]:          'pause',
-  // Note: RNAP has no 'stop' control — omit it; stop is handled by the app
   [Capability.SkipToNext]:     'next',
   [Capability.SkipToPrevious]: 'previous',
   [Capability.SeekTo]:         'seekTo',
@@ -73,8 +72,6 @@ export class NotificationBridge {
         'playbackNotificationPause',
         () => emitter.emit(Event.RemotePause)
       ),
-      // Note: RNAP has no 'stop' notification event. RemoteStop is not wired
-      // here — it fires only from app-level calls to TrackPlayer.stop().
       PlaybackNotificationManager.addEventListener(
         'playbackNotificationNext',
         () => emitter.emit(Event.RemoteNext)

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,6 @@ export enum Event {
   PlaybackActiveTrackChanged = 'playback-active-track-changed',
   RemotePlay                 = 'remote-play',
   RemotePause                = 'remote-pause',
-  RemoteStop                 = 'remote-stop',
   RemoteNext                 = 'remote-next',
   RemotePrevious             = 'remote-previous',
   RemoteSeek                 = 'remote-seek',
@@ -44,7 +43,6 @@ export enum Event {
 export enum Capability {
   Play           = 'play',
   Pause          = 'pause',
-  Stop           = 'stop',
   SkipToNext     = 'skip-to-next',
   SkipToPrevious = 'skip-to-previous',
   SeekTo         = 'seek-to',


### PR DESCRIPTION
Closes #43

## Summary

Removes two dead API values inherited from `react-native-track-player` that were never functional:

- **`Capability.Stop`** — silently ignored by `NotificationBridge`; RNAP has no stop notification control, so passing it to `updateOptions()` had no effect
- **`Event.RemoteStop`** — never emitted from any hardware or notification action; listeners received no events

## Changes

- `src/types.ts`: remove `Capability.Stop` and `Event.RemoteStop`
- `src/NotificationBridge.ts`: remove the now-redundant comment about the missing stop control and the dead-code note about `RemoteStop`

## Breaking Change

Callers referencing `Capability.Stop` or `Event.RemoteStop` will get a TypeScript error after this change. The fix is to remove those references. `TrackPlayer.stop()` remains available for programmatic stop.