### PR TITLE
feat!: remove Progress.buffered — always equals duration

### DIFF
--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -1,4 +1,4 @@
-import { Track, TrackMetadata, State, Event, PlaybackState, UpdateOptions } from './types';
+import { Track, TrackMetadata, State, Event, PlaybackState, Progress, UpdateOptions } from './types';
 import { QueueManager } from './QueueManager';
 import { PlaybackEngine } from './PlaybackEngine';
 import { NotificationBridge } from './NotificationBridge';
@@ -386,12 +386,10 @@ const TrackPlayer = {
     return engine.getDuration();
   },
 
-  async getProgress(): Promise<{ position: number; duration: number; buffered: number }> {
-    const duration = engine.getDuration();
+  async getProgress(): Promise<Progress> {
     return {
       position: engine.getPosition(),
-      duration,
-      buffered: duration,
+      duration: engine.getDuration(),
     };
   },
 };

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -380,13 +380,12 @@ describe('seekTo / getPosition / getProgress', () => {
     );
   });
 
-  it('getProgress returns position, duration, and buffered', async () => {
+  it('getProgress returns position and duration', async () => {
     await setup();
     await TrackPlayer.setQueue([track(1, 180)]);
     await TrackPlayer.play();
     const prog = await TrackPlayer.getProgress();
     expect(prog.duration).toBe(180);
-    expect(prog.buffered).toBe(180); // always equals duration in streaming mode
     expect(prog.position).toBeCloseTo(0, 4);
   });
 });

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -242,17 +242,6 @@ describe('useProgress — polling interval', () => {
     expect(getPosition.mock.calls.length).toBe(callsBeforeClear);
   });
 
-  it('buffered should always equal duration (per hook contract)', () => {
-    // The hook sets buffered: duration in every setProgress call
-    // Verify the contract by checking the Progress type shape
-    _registerProgressGetters(() => 30, () => 300, () => State.Playing);
-
-    // Simulate what the hook does: { position, duration, buffered: duration }
-    const duration = 300;
-    const progress = { position: 30, duration, buffered: duration };
-    expect(progress.buffered).toBe(progress.duration);
-  });
-
   it('PlaybackState → Paused should stop the active polling flag', () => {
     let isActive = false;
 

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -4,10 +4,7 @@ import { emitter } from '../EventEmitter';
 
 /**
  * Polls position/duration from the engine on an interval.
- * Returns { position, duration, buffered } — all in seconds.
- *
- * `buffered` always equals `duration` because decodeAudioData loads the entire
- * file into memory before playback starts.
+ * Returns { position, duration } — all in seconds.
  *
  * The getters are registered by TrackPlayer.setupPlayer() via
  * _registerProgressGetters() to avoid circular imports.
@@ -44,7 +41,6 @@ export function useProgress(updateInterval = 1000): Progress {
   const [progress, setProgress] = useState<Progress>({
     position: 0,
     duration: 0,
-    buffered: 0,
   });
 
   // Only poll while the engine is actively playing — position doesn't change
@@ -64,7 +60,7 @@ export function useProgress(updateInterval = 1000): Progress {
       isActiveRef.current = true;
       const position = _getPosition();
       const duration = _getDuration();
-      setProgress({ position, duration, buffered: duration });
+      setProgress({ position, duration });
     }
   }, []);
 
@@ -88,13 +84,13 @@ export function useProgress(updateInterval = 1000): Progress {
         // Prefer metadata duration (available immediately); fall back to the
         // engine's decoded duration for tracks without metadata.
         const duration = track.duration ?? _getDuration();
-        setProgress({ position: 0, duration, buffered: duration });
+        setProgress({ position: 0, duration });
         // The track change always accompanies the start of playback, so mark
         // the ref active so the interval begins ticking straight away.
         isActiveRef.current = true;
       } else {
         // track is null — queue was cleared or stopped
-        setProgress({ position: 0, duration: 0, buffered: 0 });
+        setProgress({ position: 0, duration: 0 });
         isActiveRef.current = false;
       }
     });
@@ -116,7 +112,7 @@ export function useProgress(updateInterval = 1000): Progress {
       setProgress(prev =>
         prev.position === position && prev.duration === duration
           ? prev
-          : { position, duration, buffered: duration }
+          : { position, duration }
       );
     }, updateInterval);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,8 +57,6 @@ export interface PlaybackState {
 export interface Progress {
   position: number;
   duration: number;
-  /** Always equals duration — the full buffer is decoded into memory. */
-  buffered: number;
 }
 
 export interface ActiveTrackChangedEvent {


### PR DESCRIPTION
Closed — rebased on current master. See replacement PR.