### PR TITLE
feat: make skipToPrevious restart threshold configurable

### DIFF
--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -319,13 +319,17 @@ const TrackPlayer = {
   },
 
   /**
-   * If more than 3 seconds into the current track, seek back to the start.
-   * Otherwise, go to the previous track.
+   * If more than `restartThreshold` seconds into the current track, seek back
+   * to the start. Otherwise, go to the previous track.
+   *
+   * @param restartThreshold - Seconds after which a "previous" press restarts
+   *   the current track instead of going back. Defaults to 3.
+   *   Pass 0 to always skip to the previous track.
    */
-  async skipToPrevious(): Promise<void> {
+  async skipToPrevious(restartThreshold = 3): Promise<void> {
     const position = engine.getPosition();
 
-    if (position > 3) {
+    if (position > restartThreshold) {
       await engine.seekTo(0);
       const track = queue.getActiveTrack();
       if (track) {

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -327,7 +327,7 @@ describe('skipToNext', () => {
 });
 
 describe('skipToPrevious', () => {
-  it('goes to the previous track when less than 3 seconds in', async () => {
+  it('goes to the previous track when less than 3 seconds in (default threshold)', async () => {
     await setup();
     await TrackPlayer.setQueue([track(1), track(2)]);
     await TrackPlayer.play();
@@ -337,7 +337,7 @@ describe('skipToPrevious', () => {
     expect(active?.title).toBe('Track 1');
   });
 
-  it('restarts the current track when more than 3 seconds in', async () => {
+  it('restarts the current track when more than 3 seconds in (default threshold)', async () => {
     await setup();
     await TrackPlayer.setQueue([track(1), track(2)]);
     await TrackPlayer.play();
@@ -358,6 +358,31 @@ describe('skipToPrevious', () => {
     // position is 0, at first track — skipToPrevious should restart
     clearCreatedStreamers();
     await TrackPlayer.skipToPrevious();
+    const active = await TrackPlayer.getActiveTrack();
+    expect(active?.title).toBe('Track 1');
+  });
+
+  it('always goes to previous when restartThreshold is 0', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    await TrackPlayer.play();
+    await TrackPlayer.skipToNext(); // on Track 2
+    getLastAudioContext()!.advanceTime(10); // well past default 3s
+    await TrackPlayer.skipToPrevious(0);
+    const active = await TrackPlayer.getActiveTrack();
+    expect(active?.title).toBe('Track 1');
+  });
+
+  it('uses a custom restartThreshold', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    await TrackPlayer.play();
+    await TrackPlayer.skipToNext(); // on Track 2
+    // Advance to 8 seconds — past default 3s but under custom 10s threshold
+    getLastAudioContext()!.advanceTime(8);
+    clearCreatedStreamers();
+    await TrackPlayer.skipToPrevious(10);
+    // Should have gone to previous track (position 8 < threshold 10)
     const active = await TrackPlayer.getActiveTrack();
     expect(active?.title).toBe('Track 1');
   });


### PR DESCRIPTION
Closes #49

## Summary

Adds a `restartThreshold` parameter to `skipToPrevious()` so callers can tune the "restart vs go back" behaviour for their app type.

```ts
skipToPrevious(restartThreshold = 3): Promise<void>
```

| App type | Recommended threshold |
|---|---|
| Music player | `3` (default — no change) |
| Podcast app | `10` |
| DJ / always-go-back | `0` |

**Non-breaking** — the default of `3` preserves current behaviour exactly.

## Changes

- `src/TrackPlayer.ts`: add `restartThreshold = 3` param; replace hardcoded `3` with it; update JSDoc
- `src/__tests__/TrackPlayer.test.ts`: add tests for `restartThreshold=0` (always previous) and custom threshold (`10`)