### PR TITLE
feat: add TrackPlayer.setVolume()

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -428,6 +428,15 @@ export class PlaybackEngine {
     return this._state;
   }
 
+  /**
+   * Set the playback volume. Clamped to [0, 1].
+   * Has no effect if the engine is not initialized.
+   */
+  setVolume(volume: number): void {
+    if (!this.gainNode) return;
+    this.gainNode.gain.value = Math.max(0, Math.min(1, volume));
+  }
+
   // ---------------------------------------------------------------------------
   // Callbacks
   // ---------------------------------------------------------------------------

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -386,6 +386,13 @@ const TrackPlayer = {
     return engine.getDuration();
   },
 
+  /**
+   * Set the playback volume. Value is clamped to [0, 1].
+   */
+  async setVolume(volume: number): Promise<void> {
+    engine.setVolume(volume);
+  },
+
   async getProgress(): Promise<{ position: number; duration: number; buffered: number }> {
     const duration = engine.getDuration();
     return {

--- a/src/__mocks__/react-native-audio-api.ts
+++ b/src/__mocks__/react-native-audio-api.ts
@@ -67,6 +67,7 @@ export { MockAudioBuffer as AudioBuffer };
 // ---------------------------------------------------------------------------
 
 export class MockGainNode {
+  gain = { value: 1 };
   connect = jest.fn();
   disconnect = jest.fn();
 }

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -392,6 +392,36 @@ describe('seekTo / getPosition / getProgress', () => {
 });
 
 // ---------------------------------------------------------------------------
+// setVolume
+// ---------------------------------------------------------------------------
+
+describe('setVolume', () => {
+  it('sets gain.value on the GainNode', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    await TrackPlayer.play();
+    await TrackPlayer.setVolume(0.5);
+    expect(getLastAudioContext()!._gainNode.gain.value).toBe(0.5);
+  });
+
+  it('clamps volume to 0 when given a negative value', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    await TrackPlayer.play();
+    await TrackPlayer.setVolume(-1);
+    expect(getLastAudioContext()!._gainNode.gain.value).toBe(0);
+  });
+
+  it('clamps volume to 1 when given a value greater than 1', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    await TrackPlayer.play();
+    await TrackPlayer.setVolume(2);
+    expect(getLastAudioContext()!._gainNode.gain.value).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Auto-advance (natural track end)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #50

## Summary

Exposes volume control via the `GainNode` that all audio paths already route through.

```ts
TrackPlayer.setVolume(0.5); // 50% volume
TrackPlayer.setVolume(0);   // mute
TrackPlayer.setVolume(1);   // full (default)
```

Volume is clamped to `[0, 1]`. No-op before `setupPlayer()` is called.

## Changes

- **`src/PlaybackEngine.ts`** — `setVolume(volume)`: clamp + write to `gainNode.gain.value`
- **`src/TrackPlayer.ts`** — `setVolume(volume): Promise<void>` delegates to engine
- **`src/__mocks__/react-native-audio-api.ts`** — add `gain = { value: 1 }` to `MockGainNode`
- **`src/__tests__/TrackPlayer.test.ts`** — tests for nominal, clamp-low, clamp-high