### PR TITLE
feat: introduce PlaybackError class for Event.PlaybackError payloads

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -6,7 +6,7 @@ import {
   type AudioBuffer,
   type StreamerNode,
 } from 'react-native-audio-api';
-import { Event, State, Track } from './types';
+import { Event, State, Track, PlaybackError } from './types';
 import { emitter } from './EventEmitter';
 
 /**
@@ -461,7 +461,7 @@ export class PlaybackEngine {
         this.setState(State.Ended);
         this.streamerNode = null;
         Promise.resolve(this.endedCallback?.()).catch((err: Error) => {
-          emitter.emit(Event.PlaybackError, { message: err.message, code: -1 });
+          emitter.emit(Event.PlaybackError, new PlaybackError(err.message, -1));
         });
       }
     }, 250);
@@ -495,7 +495,7 @@ export class PlaybackEngine {
         this.setState(State.Ended);
         this.sourceNode = null;
         Promise.resolve(this.endedCallback?.()).catch((err: Error) => {
-          emitter.emit(Event.PlaybackError, { message: err.message, code: -1 });
+          emitter.emit(Event.PlaybackError, new PlaybackError(err.message, -1));
         });
       }
     };

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -1,4 +1,4 @@
-import { Track, TrackMetadata, State, Event, PlaybackState, UpdateOptions } from './types';
+import { Track, TrackMetadata, State, Event, PlaybackState, UpdateOptions, PlaybackError } from './types';
 import { QueueManager } from './QueueManager';
 import { PlaybackEngine } from './PlaybackEngine';
 import { NotificationBridge } from './NotificationBridge';
@@ -29,10 +29,10 @@ engine.onTrackEnded(async () => {
     try {
       await engine.loadAndPlay(next);
     } catch (err: unknown) {
-      emitter.emit(Event.PlaybackError, {
-        message: err instanceof Error ? err.message : String(err),
-        code: -1,
-      });
+      emitter.emit(Event.PlaybackError, new PlaybackError(
+        err instanceof Error ? err.message : String(err),
+        -1,
+      ));
       return;
     }
     bridge.updateNowPlaying(next, State.Playing, 0).catch(console.error);

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -20,7 +20,7 @@
  */
 
 import TrackPlayer from '../TrackPlayer';
-import { Event, State } from '../types';
+import { Event, State, PlaybackError } from '../types';
 import {
   getLastAudioContext,
   getCreatedStreamers,
@@ -534,6 +534,8 @@ describe('Bug #9: silent error swallow on auto-advance', () => {
 
     // BUG #9: on unfixed code errors.length === 0
     expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toBeInstanceOf(PlaybackError);
+    expect((errors[0] as PlaybackError).code).toBe(-1);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export { default } from './TrackPlayer';
 
 // Types & enums
 export type { Track, TrackMetadata, PlaybackState, Progress, UpdateOptions, ActiveTrackChangedEvent } from './types';
-export { State, Event, Capability } from './types';
+export { State, Event, Capability, PlaybackError } from './types';
 
 // React hooks
 export { usePlaybackState } from './hooks/usePlaybackState';

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,3 +71,19 @@ export interface ActiveTrackChangedEvent {
 export interface UpdateOptions {
   capabilities?: Capability[];
 }
+
+/**
+ * Emitted as the payload of `Event.PlaybackError`.
+ *
+ * Extends `Error` so consumers get a stack trace, can use `instanceof
+ * PlaybackError`, and integrate naturally with error-monitoring tools.
+ */
+export class PlaybackError extends Error {
+  constructor(
+    message: string,
+    public readonly code: number,
+  ) {
+    super(message);
+    this.name = 'PlaybackError';
+  }
+}


### PR DESCRIPTION
Closes #38

## Summary

Replaces the plain `{ message, code }` object emitted with `Event.PlaybackError` with a proper `PlaybackError` class that extends `Error`.

```ts
export class PlaybackError extends Error {
  constructor(message: string, public readonly code: number) {
    super(message);
    this.name = 'PlaybackError';
  }
}
```

## Benefits

- Stack traces on playback errors
- `instanceof PlaybackError` checks work correctly
- Integrates with error boundaries and monitoring tools (Sentry etc.)
- `message` field remains backwards-compatible

## Changes

- **`src/types.ts`** — add `PlaybackError extends Error` with `message` + `code`
- **`src/index.ts`** — export `PlaybackError` from the package public API
- **`src/PlaybackEngine.ts`** — emit `new PlaybackError(...)` at both callback catch sites
- **`src/TrackPlayer.ts`** — emit `new PlaybackError(...)` in auto-advance catch
- **`src/__tests__/integration.test.ts`** — assert payload `instanceof PlaybackError` and `payload.code === -1` in the BUG #9 regression test