### PR TITLE
feat!: remove State.Ready enum value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,6 @@ export enum State {
   None      = 'none',
   Loading   = 'loading',
   Buffering = 'buffering',
-  Ready     = 'ready',
   Playing   = 'playing',
   Paused    = 'paused',
   Stopped   = 'stopped',


### PR DESCRIPTION
Closes #40

## Summary

`State.Ready` was designed to signal that `setupPlayer()` had completed. With lazy auto-initialization (#53), there is no explicit setup phase — the player initializes on first use. `State.Ready` has no meaningful moment to emit and was **never emitted anywhere** in the codebase.

Verified: zero references to `State.Ready` or the `'ready'` string value exist in `src/` before this change.

`State.Buffering` is intentionally retained pending investigation (#69) into native StreamerNode stall events.

## Changes

- `src/types.ts`: remove `Ready = 'ready'` from the `State` enum

## Breaking Change

`State.Ready` is removed. Callers comparing against `State.Ready` should remove the comparison — it could never have matched an emitted state.