### PR TITLE
feat!: tighten Track type — remove index signature, add id?: string

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface Track {
+  id?: string;
   url: string;
   title?: string;
   artist?: string;
@@ -6,8 +7,6 @@ export interface Track {
   genre?: string;
   artwork?: string;
   duration?: number;
-  // Open-ended: allow any extra fields callers pass through
-  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
Closes #42

## Summary

The `[key: string]: unknown` index signature was an RNTP escape hatch that broke TypeScript narrowing and gave callers false confidence that arbitrary fields are silently passed through (they are stored in `QueueManager` but never consumed by the engine or bridge).

Removing it makes `Track` a proper closed type — unknown extra keys are now a compile error, surfacing misuse early rather than silently discarding data at runtime.

`id?: string` is promoted to a first-class field. The README Quick Start already showed `id` being passed; it was previously only accepted via the index signature.

`TrackMetadata` (`= Omit<Track, 'url'>`) inherits both changes automatically.

## Changes

- `src/types.ts`: remove `[key: string]: unknown`; add `id?: string` as a first-class field

## Breaking Change

`Track` no longer accepts arbitrary extra fields. Callers passing non-standard keys will get a TypeScript error and should either remove them or maintain their own extended type.