### PR TITLE
refactor: simplify UpdateOptions — make capabilities required, add JSDoc

### DIFF
--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -108,8 +108,7 @@ const TrackPlayer = {
    * Configure playback capabilities (controls shown in the system notification).
    */
   async updateOptions(options: UpdateOptions): Promise<void> {
-    const caps = options.capabilities ?? [];
-    await bridge.setup(caps);
+    await bridge.setup(options.capabilities);
   },
 
   // --------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,8 +66,16 @@ export interface ActiveTrackChangedEvent {
   lastIndex: number;
 }
 
+/**
+ * Options passed to TrackPlayer.updateOptions().
+ *
+ * @param capabilities - Controls shown in the system media notification /
+ *   lock screen. Maps to RNAP's PlaybackNotificationManager.enableControl().
+ *   Only the listed capabilities are enabled; all others are explicitly
+ *   disabled. Defaults to all capabilities disabled if omitted.
+ */
 export interface UpdateOptions {
-  capabilities?: Capability[];
+  capabilities: Capability[];
 }
 
 /**


### PR DESCRIPTION
Closes #55

## Summary

`UpdateOptions` had a single optional field with no documentation. Two changes:

**1. Make `capabilities` required**

Passing `UpdateOptions` with no `capabilities` is a no-op — it disables all notification controls. Making it required surfaces this at the type level, preventing callers from accidentally passing `{}` and wondering why nothing shows in the media notification.

The `?? []` fallback in the implementation is removed accordingly.

**2. Add JSDoc**

Documents what `capabilities` does and how it maps to `PlaybackNotificationManager.enableControl()`.

## Changes

- `src/types.ts`: `capabilities?: Capability[]` → `capabilities: Capability[]` + JSDoc
- `src/TrackPlayer.ts`: remove `?? []` fallback (field now required)

## Breaking Change

`capabilities` is now required in `UpdateOptions`. Callers passing `{}` or omitting `capabilities` must add an explicit list (or `[]` to disable all controls).