### PR TITLE
chore: rename package to @ethanfritzt/react-native-playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-track-playback",
+  "name": "@ethanfritzt/react-native-playback",
   "version": "0.1.0",
   "description": "A React Native audio playback library built on react-native-audio-api",
   "main": "dist/index.js",
@@ -70,5 +70,9 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -2,10 +2,10 @@
 "use strict";
 
 /**
- * Expo config plugin for react-native-track-playback.
+ * Expo config plugin for @ethanfritzt/react-native-playback.
  *
  * This plugin is a thin wrapper around react-native-audio-api's own config
- * plugin. Consumers only need to add react-native-track-playback to their
+ * plugin. Consumers only need to add @ethanfritzt/react-native-playback to their
  * plugins array — they do not need to configure react-native-audio-api
  * separately.
  *
@@ -18,7 +18,7 @@
  * Usage in app.json / app.config.js:
  *   {
  *     "plugins": [
- *       ["react-native-track-playback", { "iosBackgroundMode": true }]
+ *       ["@ethanfritzt/react-native-playback", { "iosBackgroundMode": true }]
  *     ]
  *   }
  */
@@ -37,7 +37,7 @@ function getRNAPPlugin() {
     return rnap.default ?? rnap;
   } catch {
     throw new Error(
-      "[react-native-track-playback] Could not find react-native-audio-api plugin.\n" +
+      "[@ethanfritzt/react-native-playback] Could not find react-native-audio-api plugin.\n" +
         "Make sure react-native-audio-api is installed:\n" +
         "  npx expo install react-native-audio-api\n",
     );
@@ -91,6 +91,6 @@ function withTrackPlayback(config, options = {}) {
 
 module.exports = createRunOncePlugin(
   withTrackPlayback,
-  "react-native-track-playback",
+  "@ethanfritzt/react-native-playback",
   "0.1.0",
 );

--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -29,7 +29,7 @@ import { emitter } from './EventEmitter';
  *
  * To enable StreamerNode, the react-native-audio-api plugin must be built with FFmpeg
  * (disableFFmpeg: false, which is the default and is explicitly forwarded by the
- * react-native-track-playback Expo plugin).
+ * @ethanfritzt/react-native-playback Expo plugin).
  *
  * ## Position tracking
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * react-native-track-playback
+ * @ethanfritzt/react-native-playback
  *
  * A React Native audio playback library built on react-native-audio-api.
  *
  * Usage:
  *   import TrackPlayer, { State, Event, Capability, usePlaybackState, useProgress, useActiveTrack }
- *     from 'react-native-track-playback';
+ *     from '@ethanfritzt/react-native-playback';
  */
 
 // Default export — the static TrackPlayer API


### PR DESCRIPTION
Closes #78

## Summary

Renames the package from `react-native-track-playback` to `@ethanfritzt/react-native-playback`.

- `react-native-playback` (unscoped) is already taken on npm
- `@ethanfritzt/react-native-playback` is confirmed available
- Scoped packages avoid crowding the react-native namespace

## Changes

- **`package.json`** — `name` updated; `publishConfig` added for GitHub Packages registry
- **`src/index.ts`** — usage comment and import example updated
- **`src/PlaybackEngine.ts`** — JSDoc plugin name reference updated
- **`plugin/index.js`** — all internal name references and error messages updated