### PR TITLE
fix: remove State.Ready — unused after lazy init

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ const { position, duration } = useProgress(500);
 ```typescript
 enum State {
   None = 'none',
-  Ready = 'ready',
+  Loading = 'loading',
+  Buffering = 'buffering',
   Playing = 'playing',
   Paused = 'paused',
   Stopped = 'stopped',
   Ended = 'ended',
-  Loading = 'loading',
   Error = 'error',
 }
 ```

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -238,9 +238,9 @@ const TrackPlayer = {
       return;
     }
 
-    // For all other states (Stopped, None, Ended, Error, Loading, Buffering, Ready):
+    // For all other states (Stopped, None, Ended, Error, Loading, Buffering):
     // cancel any in-flight load and start the active track from the beginning.
-    // Loading/Buffering/Ready can occur if setQueue() was called while a previous
+    // Loading/Buffering can occur if setQueue() was called while a previous
     // load was in-flight — engine.loadAndPlay() increments loadGeneration, which
     // cancels the stale load before starting fresh.
     const track = queue.getActiveTrack();

--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -192,7 +192,7 @@ describe('loadAndPlay (buffer fallback path)', () => {
     expect(decodeAudioData).toHaveBeenCalledWith(track.url);
   });
 
-  it('transitions through Buffering → Ready → Playing', async () => {
+  it('transitions through Buffering → Playing', async () => {
     const engine = makeEngine();
     // const states: State[] = []; // removed — unused
     // Patch setState indirectly by observing state at each promise tick


### PR DESCRIPTION
## Summary

Closes #40

`State.Ready` was designed to signal that `setupPlayer()` had completed and the player was ready for use. With lazy initialization (#68), there is no setup phase — the player initializes on first use. `State.Ready` was never emitted and has no meaningful moment to emit.

## Changes

- **`README.md`** — Remove `Ready = 'ready'` from the Playback States code block; also sync the enum to match actual `types.ts` (adds `Buffering`, corrects order)
- **`src/TrackPlayer.ts`** — Remove stale `Ready` references from two inline comments
- **`src/__tests__/PlaybackEngine.test.ts`** — Update test description: `Buffering → Ready → Playing` → `Buffering → Playing`

## Notes

`State.Buffering` is intentionally kept — investigation of StreamerNode stall events is tracked in #73.