### PR TITLE
fix: rename Capability to Control, align names with react-native-audio-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Breaking Changes
+- Renamed `Capability` enum to `Control`; values now match `react-native-audio-api`'s `PlaybackControlName` exactly (`nextTrack`, `previousTrack`, `skipForward`, `skipBackward`, `seekTo`). `Stop` was removed (no RNAP equivalent); `SkipForward` and `SkipBackward` were added. `UpdateOptions.capabilities` renamed to `UpdateOptions.controls`.
+
 ## [0.1.0] — 2026-04-04
 
 Initial release of `react-native-track-playback`.

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -1,5 +1,5 @@
 import { PlaybackNotificationManager } from 'react-native-audio-api';
-import { Capability, Event, State, Track } from './types';
+import { Control, Event, State, Track } from './types';
 import { emitter } from './EventEmitter';
 
 /**
@@ -9,16 +9,6 @@ import { emitter } from './EventEmitter';
  * Also handles updating the lock screen / notification metadata whenever
  * the active track or playback state changes.
  */
-
-// Maps our Capability enum values to RNAP's PlaybackControlName strings
-const CAPABILITY_TO_CONTROL: Partial<Record<Capability, string>> = {
-  [Capability.Play]:           'play',
-  [Capability.Pause]:          'pause',
-  // Note: RNAP has no 'stop' control — omit it; stop is handled by the app
-  [Capability.SkipToNext]:     'next',
-  [Capability.SkipToPrevious]: 'previous',
-  [Capability.SeekTo]:         'seekTo',
-};
 
 type RNAPSubscription = { remove: () => void };
 
@@ -36,7 +26,7 @@ export class NotificationBridge {
   // Setup / teardown
   // ---------------------------------------------------------------------------
 
-  async setup(capabilities: Capability[]): Promise<void> {
+  async setup(controls: Control[]): Promise<void> {
     this.teardown();
 
     // Enable only the requested controls; disable everything else.
@@ -44,20 +34,16 @@ export class NotificationBridge {
     // explicitly disabled (RNAP doesn't disable by default).
     // Only controls whose enabled/disabled state has changed since the last
     // setup() call are sent — this avoids redundant async work when
-    // updateOptions() is called more than once (e.g. per-track capability changes).
-    const allRNAPControls = ['play', 'pause', 'next', 'previous', 'skipForward', 'skipBackward', 'seekTo'] as const;
+    // updateOptions() is called more than once (e.g. per-track control changes).
+    const allRNAPControls = ['play', 'pause', 'stop', 'nextTrack', 'previousTrack', 'skipForward', 'skipBackward', 'seekTo'] as const;
     const changed = allRNAPControls.filter(control => {
-      const isEnabled = capabilities.some(
-        cap => CAPABILITY_TO_CONTROL[cap] === control
-      );
+      const isEnabled = (controls as string[]).includes(control);
       return this.appliedControls.get(control) !== isEnabled;
     });
 
     await Promise.all(
       changed.map(control => {
-        const isEnabled = capabilities.some(
-          cap => CAPABILITY_TO_CONTROL[cap] === control
-        );
+        const isEnabled = (controls as string[]).includes(control);
         this.appliedControls.set(control, isEnabled);
         return PlaybackNotificationManager.enableControl(control, isEnabled);
       })

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -35,7 +35,7 @@ export class NotificationBridge {
     // Only controls whose enabled/disabled state has changed since the last
     // setup() call are sent — this avoids redundant async work when
     // updateOptions() is called more than once (e.g. per-track control changes).
-    const allRNAPControls = ['play', 'pause', 'stop', 'nextTrack', 'previousTrack', 'skipForward', 'skipBackward', 'seekTo'] as const;
+    const allRNAPControls = ['play', 'pause', 'next', 'previous', 'skipForward', 'skipBackward', 'seekTo'] as const;
     const changed = allRNAPControls.filter(control => {
       const isEnabled = (controls as string[]).includes(control);
       return this.appliedControls.get(control) !== isEnabled;

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -112,10 +112,10 @@ const TrackPlayer = {
   },
 
   /**
-   * Configure playback capabilities (controls shown in the system notification).
+   * Configure playback controls (controls shown in the system notification).
    */
   async updateOptions(options: UpdateOptions): Promise<void> {
-    await bridge.setup(options.capabilities);
+    await bridge.setup(options.controls);
   },
 
   // --------------------------------------------------------------------------

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -37,7 +37,7 @@ function track(n: number, duration = 30) {
 
 async function setup() {
   await TrackPlayer.updateOptions({
-    capabilities: [],
+    controls: [],
   });
 }
 
@@ -58,7 +58,7 @@ afterEach(() => {
 
 describe('updateOptions', () => {
   it('calls PlaybackNotificationManager.enableControl for each known control', async () => {
-    await TrackPlayer.updateOptions({ capabilities: [] });
+    await TrackPlayer.updateOptions({ controls: [] });
     // 7 controls total (play, pause, next, previous, skipForward, skipBackward, seekTo)
     expect(PlaybackNotificationManager.enableControl).toHaveBeenCalledTimes(7);
   });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -48,7 +48,7 @@ function track(n: number, duration = 60) {
 }
 
 async function setup() {
-  await TrackPlayer.updateOptions({ capabilities: [] });
+  await TrackPlayer.updateOptions({ controls: [] });
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * A React Native audio playback library built on react-native-audio-api.
  *
  * Usage:
- *   import TrackPlayer, { State, Event, Capability, usePlaybackState, useProgress, useActiveTrack }
+ *   import TrackPlayer, { State, Event, Control, usePlaybackState, useProgress, useActiveTrack }
  *     from 'react-native-track-playback';
  */
 
@@ -16,7 +16,7 @@ export { default } from './TrackPlayer';
 
 // Types & enums
 export type { Track, TrackMetadata, PlaybackState, Progress, UpdateOptions, ActiveTrackChangedEvent, RemoteSeekEvent, EventPayloadMap, Subscription } from './types';
-export { State, Event, Capability, PlaybackError } from './types';
+export { State, Event, Control, PlaybackError } from './types';
 
 // React hooks
 export { usePlaybackState } from './hooks/usePlaybackState';

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,13 +39,14 @@ export enum Event {
   RemoteSeek                 = 'remote-seek',
 }
 
-export enum Capability {
-  Play           = 'play',
-  Pause          = 'pause',
-  Stop           = 'stop',
-  SkipToNext     = 'skip-to-next',
-  SkipToPrevious = 'skip-to-previous',
-  SeekTo         = 'seek-to',
+export enum Control {
+  Play          = 'play',
+  Pause         = 'pause',
+  NextTrack     = 'nextTrack',
+  PreviousTrack = 'previousTrack',
+  SkipForward   = 'skipForward',
+  SkipBackward  = 'skipBackward',
+  SeekTo        = 'seekTo',
 }
 
 export interface PlaybackState {
@@ -69,13 +70,13 @@ export interface ActiveTrackChangedEvent {
 /**
  * Options passed to TrackPlayer.updateOptions().
  *
- * @param capabilities - Controls shown in the system media notification /
+ * @param controls - Controls shown in the system media notification /
  *   lock screen. Maps to RNAP's PlaybackNotificationManager.enableControl().
- *   Only the listed capabilities are enabled; all others are explicitly
- *   disabled. Defaults to all capabilities disabled if omitted.
+ *   Only the listed controls are enabled; all others are explicitly
+ *   disabled. Defaults to all controls disabled if omitted.
  */
 export interface UpdateOptions {
-  capabilities: Capability[];
+  controls: Control[];
 }
 
 /**


### PR DESCRIPTION
Closes #99

## Changes
- Renamed `Capability` → `Control` enum
- Values now match react-native-audio-api's `PlaybackControlName` exactly
- `SkipToNext` → `NextTrack`, `SkipToPrevious` → `PreviousTrack`, `SeekTo` → `seekTo` (value fix)
- Added `SkipForward` and `SkipBackward`
- Removed `Stop` (no RNAP equivalent)
- `UpdateOptions.capabilities` → `UpdateOptions.controls`
- Removed now-unnecessary `CAPABILITY_TO_CONTROL` mapping in NotificationBridge