### PR TITLE
fix: replace onTrackEnded callback with emitter listener

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -82,7 +82,7 @@ export class PlaybackEngine {
   private _state: State = State.None;
 
   /** Called by TrackPlayer when a track ends naturally (not via stop/skip). */
-  private endedCallback: (() => void) | null = null;
+
 
   /**
    * True when the AudioContext's createStreamer() returned a non-null node,
@@ -429,14 +429,6 @@ export class PlaybackEngine {
   }
 
   // ---------------------------------------------------------------------------
-  // Callbacks
-  // ---------------------------------------------------------------------------
-
-  onTrackEnded(cb: () => void): void {
-    this.endedCallback = cb;
-  }
-
-  // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
 
@@ -460,9 +452,7 @@ export class PlaybackEngine {
         this.clearStreamerEndedPoller();
         this.setState(State.Ended);
         this.streamerNode = null;
-        Promise.resolve(this.endedCallback?.()).catch((err: Error) => {
-          emitter.emit(Event.PlaybackError, new PlaybackError(err.message, -1));
-        });
+        emitter.emit(Event.TrackEnded);
       }
     }, 250);
   }
@@ -494,9 +484,7 @@ export class PlaybackEngine {
       if (this._state === State.Playing) {
         this.setState(State.Ended);
         this.sourceNode = null;
-        Promise.resolve(this.endedCallback?.()).catch((err: Error) => {
-          emitter.emit(Event.PlaybackError, new PlaybackError(err.message, -1));
-        });
+        emitter.emit(Event.TrackEnded);
       }
     };
 

--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -6,7 +6,7 @@ import {
   type AudioBuffer,
   type StreamerNode,
 } from 'react-native-audio-api';
-import { Event, State, Track, PlaybackError } from './types';
+import { Event, State, Track } from './types';
 import { emitter } from './EventEmitter';
 
 /**

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -39,7 +39,7 @@ _registerActiveTrackGetter(() => queue.getActiveTrack() ?? null);
 
 // Wire auto-advance: when a track ends naturally, move to the next one.
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
-emitter.addEventListener(Event.TrackEnded, async () => {
+emitter.on(Event.TrackEnded, async () => {
   const lastTrack = queue.getActiveTrack() ?? null;
   const lastIndex = queue.getActiveIndex();
   const advanced = queue.skipToNext();

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -39,7 +39,7 @@ _registerActiveTrackGetter(() => queue.getActiveTrack() ?? null);
 
 // Wire auto-advance: when a track ends naturally, move to the next one.
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
-engine.onTrackEnded(async () => {
+emitter.addEventListener(Event.TrackEnded, async () => {
   const lastTrack = queue.getActiveTrack() ?? null;
   const lastIndex = queue.getActiveIndex();
   const advanced = queue.skipToNext();

--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -428,7 +428,7 @@ describe('TrackEnded event', () => {
   it('emits TrackEnded when the streamer poller detects end', async () => {
     const engine = makeEngine();
     const cb = jest.fn();
-    const sub = emitter.addEventListener(Event.TrackEnded, cb);
+    const unsub = emitter.on(Event.TrackEnded, cb);
 
     await engine.loadAndPlay(makeTrack(1, 30));
     const ctx = getLastAudioContext()!;
@@ -437,13 +437,13 @@ describe('TrackEnded event', () => {
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(engine.getState()).toBe(State.Ended);
-    sub.remove();
+    unsub();
   });
 
   it('does NOT emit TrackEnded when stop() was called before poller fires', async () => {
     const engine = makeEngine();
     const cb = jest.fn();
-    const sub = emitter.addEventListener(Event.TrackEnded, cb);
+    const unsub = emitter.on(Event.TrackEnded, cb);
 
     await engine.loadAndPlay(makeTrack(1, 30));
     await engine.stop(); // state → Stopped, poller cleared
@@ -452,14 +452,14 @@ describe('TrackEnded event', () => {
     jest.advanceTimersByTime(250);
 
     expect(cb).not.toHaveBeenCalled();
-    sub.remove();
+    unsub();
   });
 
   it('emits TrackEnded when the buffer source ends naturally (buffer path)', async () => {
     setStreamerAvailable(false);
     const engine = makeEngine();
     const cb = jest.fn();
-    const sub = emitter.addEventListener(Event.TrackEnded, cb);
+    const unsub = emitter.on(Event.TrackEnded, cb);
 
     await engine.loadAndPlay(makeTrack());
     const sources = getCreatedSources();
@@ -468,7 +468,7 @@ describe('TrackEnded event', () => {
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(engine.getState()).toBe(State.Ended);
-    sub.remove();
+    unsub();
   });
 });
 

--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -1,5 +1,6 @@
 import { PlaybackEngine } from '../PlaybackEngine';
-import { State } from '../types';
+import { State, Event } from '../types';
+import { emitter } from '../EventEmitter';
 import {
   getLastAudioContext,
   getCreatedStreamers,
@@ -423,11 +424,11 @@ describe('seekTo (buffer fallback path)', () => {
 // Natural track end
 // ---------------------------------------------------------------------------
 
-describe('onTrackEnded callback', () => {
-  it('fires the callback when the streamer poller detects end', async () => {
+describe('TrackEnded event', () => {
+  it('emits TrackEnded when the streamer poller detects end', async () => {
     const engine = makeEngine();
     const cb = jest.fn();
-    engine.onTrackEnded(cb);
+    const sub = emitter.addEventListener(Event.TrackEnded, cb);
 
     await engine.loadAndPlay(makeTrack(1, 30));
     const ctx = getLastAudioContext()!;
@@ -436,12 +437,13 @@ describe('onTrackEnded callback', () => {
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(engine.getState()).toBe(State.Ended);
+    sub.remove();
   });
 
-  it('does NOT fire callback when stop() was called before poller fires', async () => {
+  it('does NOT emit TrackEnded when stop() was called before poller fires', async () => {
     const engine = makeEngine();
     const cb = jest.fn();
-    engine.onTrackEnded(cb);
+    const sub = emitter.addEventListener(Event.TrackEnded, cb);
 
     await engine.loadAndPlay(makeTrack(1, 30));
     await engine.stop(); // state → Stopped, poller cleared
@@ -450,13 +452,14 @@ describe('onTrackEnded callback', () => {
     jest.advanceTimersByTime(250);
 
     expect(cb).not.toHaveBeenCalled();
+    sub.remove();
   });
 
-  it('fires the callback when the buffer source ends naturally (buffer path)', async () => {
+  it('emits TrackEnded when the buffer source ends naturally (buffer path)', async () => {
     setStreamerAvailable(false);
     const engine = makeEngine();
     const cb = jest.fn();
-    engine.onTrackEnded(cb);
+    const sub = emitter.addEventListener(Event.TrackEnded, cb);
 
     await engine.loadAndPlay(makeTrack());
     const sources = getCreatedSources();
@@ -465,6 +468,7 @@ describe('onTrackEnded callback', () => {
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(engine.getState()).toBe(State.Ended);
+    sub.remove();
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export enum Event {
   RemoteNext                 = 'remote-next',
   RemotePrevious             = 'remote-previous',
   RemoteSeek                 = 'remote-seek',
+  /** @internal Emitted by PlaybackEngine when a track ends naturally. */
+  TrackEnded                 = 'internal-track-ended',
 }
 
 export enum Capability {
@@ -113,6 +115,7 @@ export interface EventPayloadMap {
   [Event.RemoteNext]: void;
   [Event.RemotePrevious]: void;
   [Event.RemoteSeek]: RemoteSeekEvent;
+  [Event.TrackEnded]: void;
 }
 
 /** Returned by addEventListener — call remove() to unsubscribe. */


### PR DESCRIPTION
Closes #100

## Changes
- Added `Event.TrackEnded = 'internal-track-ended'` as an internal event to `types.ts`
- Removed `endedCallback` field and `onTrackEnded()` method from `PlaybackEngine`
- `PlaybackEngine` now emits `Event.TrackEnded` directly when a track ends naturally (both streamer poller path and buffer source `onEnded` path)
- `TrackPlayer` now listens via `emitter.addEventListener(Event.TrackEnded, ...)` instead of calling `engine.onTrackEnded()`
- Updated `PlaybackEngine.test.ts` to test the emitter event instead of the removed callback