### PR TITLE
feat: auto-wire remote event handlers with optional overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- `UpdateOptions.remoteHandlers`: optional per-event overrides for remote control events (`onRemotePlay`, `onRemotePause`, `onRemoteStop`, `onRemoteNext`, `onRemotePrevious`, `onRemoteSeek`)
+- Default remote event handlers are now wired internally in `updateOptions()` — consumers no longer need to manually call `addEventListener` for standard play/pause/next/previous/seek/stop behavior
+- `EventPayloadMap` now includes `Event.RemoteStop` (was missing)
+
 ## [0.1.0] — 2026-04-04
 
 Initial release of `react-native-track-playback`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react": "^19.2.4",
         "react-native": "^0.84.1",
         "react-native-audio-api": "^0.11.6",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3"
@@ -3860,7 +3860,6 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3871,7 +3870,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3940,7 +3938,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4439,7 +4436,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4854,7 +4850,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5417,7 +5412,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5490,7 +5484,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6384,9 +6377,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11447,7 +11440,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11476,7 +11468,6 @@
       "integrity": "sha512-0PjxOyXRu3tZ8EobabxSukvhKje2HJbsZikR0U+pvS0pYZza2hXKjcSBiBdFN4h9D0S3v6a8kkrDK6WTRKMwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.84.1",
@@ -12362,19 +12353,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -12391,7 +12382,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -12433,7 +12424,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12582,7 +12572,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react": "^19.2.4",
     "react-native": "^0.84.1",
     "react-native-audio-api": "^0.11.6",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -6,6 +6,7 @@ import {
   PlaybackState,
   Progress,
   UpdateOptions,
+  RemoteHandlers,
   PlaybackError,
   EventPayloadMap,
   Subscription,
@@ -91,6 +92,34 @@ engine.onTrackEnded(async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Remote handler wiring
+// ---------------------------------------------------------------------------
+
+let remoteSubscriptions: Subscription[] = [];
+
+function wireRemoteHandlers(overrides: RemoteHandlers = {}): void {
+  // Remove previous wiring
+  remoteSubscriptions.forEach(s => s.remove());
+  remoteSubscriptions = [];
+
+  const sub = <E extends keyof EventPayloadMap>(
+    event: E,
+    handler: (payload: EventPayloadMap[E]) => void | Promise<void>
+  ) => {
+    remoteSubscriptions.push(
+      TrackPlayer.addEventListener(event, handler as (payload: EventPayloadMap[E]) => void)
+    );
+  };
+
+  sub(Event.RemotePlay, overrides.onRemotePlay ?? (() => TrackPlayer.play()));
+  sub(Event.RemotePause, overrides.onRemotePause ?? (() => TrackPlayer.pause()));
+  sub(Event.RemoteStop, overrides.onRemoteStop ?? (() => TrackPlayer.stop()));
+  sub(Event.RemoteNext, overrides.onRemoteNext ?? (() => TrackPlayer.skipToNext()));
+  sub(Event.RemotePrevious, overrides.onRemotePrevious ?? (() => TrackPlayer.skipToPrevious()));
+  sub(Event.RemoteSeek, overrides.onRemoteSeek ?? (({ position }) => TrackPlayer.seekTo(position)));
+}
+
+// ---------------------------------------------------------------------------
 // TrackPlayer public API
 // ---------------------------------------------------------------------------
 
@@ -106,16 +135,24 @@ const TrackPlayer = {
    * call.
    */
   async destroy(): Promise<void> {
+    remoteSubscriptions.forEach(s => s.remove());
+    remoteSubscriptions = [];
     await engine.destroy();
     bridge.teardown();
     queue.reset();
   },
 
   /**
-   * Configure playback capabilities (controls shown in the system notification).
+   * Configure playback capabilities (controls shown in the system notification)
+   * and optionally override default remote event handlers.
+   *
+   * Default handlers for RemotePlay, RemotePause, RemoteStop, RemoteNext,
+   * RemotePrevious, and RemoteSeek are wired automatically. Pass
+   * `remoteHandlers` to replace any of them with custom behavior.
    */
   async updateOptions(options: UpdateOptions): Promise<void> {
     await bridge.setup(options.capabilities);
+    wireRemoteHandlers(options.remoteHandlers);
   },
 
   // --------------------------------------------------------------------------

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -136,7 +136,7 @@ const TrackPlayer = {
   },
 
   /**
-   * Configure playback capabilities (controls shown in the system notification)
+   * Configure playback controls (controls shown in the system notification)
    * and optionally override default remote event handlers.
    *
    * Default handlers for RemotePlay, RemotePause, RemoteStop, RemoteNext,
@@ -144,7 +144,7 @@ const TrackPlayer = {
    * `remoteHandlers` to replace any of them with custom behavior.
    */
   async updateOptions(options: UpdateOptions): Promise<void> {
-    await bridge.setup(options.capabilities);
+    await bridge.setup(options.controls);
     wireRemoteHandlers(options.remoteHandlers);
   },
 

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -642,7 +642,7 @@ describe('remote handlers', () => {
   it('custom onRemoteNext overrides default skipToNext', async () => {
     const customNext = jest.fn();
     await TrackPlayer.updateOptions({
-      capabilities: [],
+      controls: [],
       remoteHandlers: { onRemoteNext: customNext },
     });
     await TrackPlayer.setQueue([track(1), track(2)]);
@@ -659,7 +659,7 @@ describe('remote handlers', () => {
   it('custom onRemotePlay overrides default play()', async () => {
     const customPlay = jest.fn();
     await TrackPlayer.updateOptions({
-      capabilities: [],
+      controls: [],
       remoteHandlers: { onRemotePlay: customPlay },
     });
     await TrackPlayer.setQueue([track(1)]);
@@ -676,9 +676,9 @@ describe('remote handlers', () => {
     const first = jest.fn();
     const second = jest.fn();
 
-    await TrackPlayer.updateOptions({ capabilities: [], remoteHandlers: { onRemotePlay: first } });
+    await TrackPlayer.updateOptions({ controls: [], remoteHandlers: { onRemotePlay: first } });
     // Replace with second handler
-    await TrackPlayer.updateOptions({ capabilities: [], remoteHandlers: { onRemotePlay: second } });
+    await TrackPlayer.updateOptions({ controls: [], remoteHandlers: { onRemotePlay: second } });
 
     emitter.emit(Event.RemotePlay);
     await flushAsync();
@@ -689,7 +689,7 @@ describe('remote handlers', () => {
 
   it('destroy() removes remote subscriptions', async () => {
     const customPlay = jest.fn();
-    await TrackPlayer.updateOptions({ capabilities: [], remoteHandlers: { onRemotePlay: customPlay } });
+    await TrackPlayer.updateOptions({ controls: [], remoteHandlers: { onRemotePlay: customPlay } });
 
     await TrackPlayer.destroy();
 

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -13,6 +13,7 @@
 
 import TrackPlayer from '../TrackPlayer';
 import { Event, State } from '../types';
+import { emitter } from '../EventEmitter';
 import {
   getLastAudioContext,
   getCreatedStreamers,
@@ -561,5 +562,140 @@ describe('getActiveTrackIndex', () => {
     await TrackPlayer.play();
     await TrackPlayer.skipToNext();
     expect(TrackPlayer.getActiveTrackIndex()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// remote handlers
+// ---------------------------------------------------------------------------
+
+/** Flush all pending microtasks / promises */
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('remote handlers', () => {
+  it('default RemotePlay triggers play and transitions to Playing', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    // Ensure we start from Stopped state
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Stopped);
+
+    emitter.emit(Event.RemotePlay);
+    await flushAsync();
+
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Playing);
+  });
+
+  it('default RemotePause pauses playback', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    await TrackPlayer.play();
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Playing);
+
+    emitter.emit(Event.RemotePause);
+    await flushAsync();
+
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Paused);
+  });
+
+  it('default RemoteStop stops playback', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    await TrackPlayer.play();
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Playing);
+
+    emitter.emit(Event.RemoteStop);
+    await flushAsync();
+
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Stopped);
+  });
+
+  it('default RemoteNext advances to the next track', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    await TrackPlayer.play();
+    expect(TrackPlayer.getActiveTrackIndex()).toBe(0);
+
+    emitter.emit(Event.RemoteNext);
+    await flushAsync();
+
+    expect(TrackPlayer.getActiveTrackIndex()).toBe(1);
+  });
+
+  it('default RemotePrevious goes to the previous track', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    await TrackPlayer.play();
+    await TrackPlayer.skipToNext();
+    expect(TrackPlayer.getActiveTrackIndex()).toBe(1);
+
+    emitter.emit(Event.RemotePrevious);
+    await flushAsync();
+
+    // skipToPrevious with position <= 3 goes back to track index 0
+    expect(TrackPlayer.getActiveTrackIndex()).toBe(0);
+  });
+
+  it('custom onRemoteNext overrides default skipToNext', async () => {
+    const customNext = jest.fn();
+    await TrackPlayer.updateOptions({
+      capabilities: [],
+      remoteHandlers: { onRemoteNext: customNext },
+    });
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    await TrackPlayer.play();
+
+    emitter.emit(Event.RemoteNext);
+    await flushAsync();
+
+    expect(customNext).toHaveBeenCalled();
+    // Default skipToNext was NOT called — index stays at 0
+    expect(TrackPlayer.getActiveTrackIndex()).toBe(0);
+  });
+
+  it('custom onRemotePlay overrides default play()', async () => {
+    const customPlay = jest.fn();
+    await TrackPlayer.updateOptions({
+      capabilities: [],
+      remoteHandlers: { onRemotePlay: customPlay },
+    });
+    await TrackPlayer.setQueue([track(1)]);
+
+    emitter.emit(Event.RemotePlay);
+    await flushAsync();
+
+    expect(customPlay).toHaveBeenCalled();
+    // Default play was NOT called — still Stopped
+    expect(TrackPlayer.getPlaybackState().state).toBe(State.Stopped);
+  });
+
+  it('re-wires handlers on each updateOptions call', async () => {
+    const first = jest.fn();
+    const second = jest.fn();
+
+    await TrackPlayer.updateOptions({ capabilities: [], remoteHandlers: { onRemotePlay: first } });
+    // Replace with second handler
+    await TrackPlayer.updateOptions({ capabilities: [], remoteHandlers: { onRemotePlay: second } });
+
+    emitter.emit(Event.RemotePlay);
+    await flushAsync();
+
+    expect(second).toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it('destroy() removes remote subscriptions', async () => {
+    const customPlay = jest.fn();
+    await TrackPlayer.updateOptions({ capabilities: [], remoteHandlers: { onRemotePlay: customPlay } });
+
+    await TrackPlayer.destroy();
+
+    emitter.emit(Event.RemotePlay);
+    await flushAsync();
+
+    expect(customPlay).not.toHaveBeenCalled();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,15 +67,33 @@ export interface ActiveTrackChangedEvent {
 }
 
 /**
+ * Optional overrides for remote control events. Each key corresponds to a
+ * remote event; if provided, the function replaces the default handler for
+ * that event. If omitted, the default behavior is used.
+ */
+export interface RemoteHandlers {
+  onRemotePlay?: () => void | Promise<void>;
+  onRemotePause?: () => void | Promise<void>;
+  onRemoteStop?: () => void | Promise<void>;
+  onRemoteNext?: () => void | Promise<void>;
+  onRemotePrevious?: () => void | Promise<void>;
+  onRemoteSeek?: (event: RemoteSeekEvent) => void | Promise<void>;
+}
+
+/**
  * Options passed to TrackPlayer.updateOptions().
  *
  * @param capabilities - Controls shown in the system media notification /
  *   lock screen. Maps to RNAP's PlaybackNotificationManager.enableControl().
  *   Only the listed capabilities are enabled; all others are explicitly
  *   disabled. Defaults to all capabilities disabled if omitted.
+ * @param remoteHandlers - Optional per-event overrides for remote control
+ *   events. Omitting a handler uses the default behavior; providing one
+ *   replaces it entirely.
  */
 export interface UpdateOptions {
   capabilities: Capability[];
+  remoteHandlers?: RemoteHandlers;
 }
 
 /**
@@ -110,6 +128,7 @@ export interface EventPayloadMap {
   [Event.PlaybackActiveTrackChanged]: ActiveTrackChangedEvent;
   [Event.RemotePlay]: void;
   [Event.RemotePause]: void;
+  [Event.RemoteStop]: void;
   [Event.RemoteNext]: void;
   [Event.RemotePrevious]: void;
   [Event.RemoteSeek]: RemoteSeekEvent;


### PR DESCRIPTION
Closes #101

## Changes
- Default remote handlers (play/pause/stop/next/previous/seek) are now wired internally in `updateOptions()` — consumers no longer need boilerplate event listeners
- Added `RemoteHandlers` interface and `UpdateOptions.remoteHandlers?` for per-event overrides — omitting a handler uses the default, providing one replaces it entirely
- Remote subscriptions are re-wired on each `updateOptions()` call and cleared on `destroy()`
- Added `Event.RemoteStop` to `EventPayloadMap` (was missing)
- Added integration tests for default and override handler behavior