### PR TITLE
feat: add useQueue hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3860,7 +3860,6 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3871,7 +3870,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3940,7 +3938,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4439,7 +4436,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4854,7 +4850,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5417,7 +5412,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5490,7 +5484,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11447,7 +11440,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11476,7 +11468,6 @@
       "integrity": "sha512-0PjxOyXRu3tZ8EobabxSukvhKje2HJbsZikR0U+pvS0pYZza2hXKjcSBiBdFN4h9D0S3v6a8kkrDK6WTRKMwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.84.1",
@@ -12433,7 +12424,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12582,7 +12572,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -20,7 +20,7 @@ export class EventEmitter {
   }
 
   emit(event: string, ...args: unknown[]): void {
-    this.listeners.get(event)?.forEach(h => h(...args));
+    this.listeners.get(event)?.forEach((h) => h(...args));
   }
 }
 

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -12,12 +12,12 @@ import { emitter } from './EventEmitter';
 
 // Maps our Capability enum values to RNAP's PlaybackControlName strings
 const CAPABILITY_TO_CONTROL: Partial<Record<Capability, string>> = {
-  [Capability.Play]:           'play',
-  [Capability.Pause]:          'pause',
+  [Capability.Play]: 'play',
+  [Capability.Pause]: 'pause',
   // Note: RNAP has no 'stop' control — omit it; stop is handled by the app
-  [Capability.SkipToNext]:     'next',
+  [Capability.SkipToNext]: 'next',
   [Capability.SkipToPrevious]: 'previous',
-  [Capability.SeekTo]:         'seekTo',
+  [Capability.SeekTo]: 'seekTo',
 };
 
 type RNAPSubscription = { remove: () => void };
@@ -45,19 +45,23 @@ export class NotificationBridge {
     // Only controls whose enabled/disabled state has changed since the last
     // setup() call are sent — this avoids redundant async work when
     // updateOptions() is called more than once (e.g. per-track capability changes).
-    const allRNAPControls = ['play', 'pause', 'next', 'previous', 'skipForward', 'skipBackward', 'seekTo'] as const;
-    const changed = allRNAPControls.filter(control => {
-      const isEnabled = capabilities.some(
-        cap => CAPABILITY_TO_CONTROL[cap] === control
-      );
+    const allRNAPControls = [
+      'play',
+      'pause',
+      'next',
+      'previous',
+      'skipForward',
+      'skipBackward',
+      'seekTo',
+    ] as const;
+    const changed = allRNAPControls.filter((control) => {
+      const isEnabled = capabilities.some((cap) => CAPABILITY_TO_CONTROL[cap] === control);
       return this.appliedControls.get(control) !== isEnabled;
     });
 
     await Promise.all(
-      changed.map(control => {
-        const isEnabled = capabilities.some(
-          cap => CAPABILITY_TO_CONTROL[cap] === control
-        );
+      changed.map((control) => {
+        const isEnabled = capabilities.some((cap) => CAPABILITY_TO_CONTROL[cap] === control);
         this.appliedControls.set(control, isEnabled);
         return PlaybackNotificationManager.enableControl(control, isEnabled);
       })
@@ -65,23 +69,19 @@ export class NotificationBridge {
 
     // Wire RNAP notification events → package EventEmitter
     this.subscriptions = [
-      PlaybackNotificationManager.addEventListener(
-        'playbackNotificationPlay',
-        () => emitter.emit(Event.RemotePlay)
+      PlaybackNotificationManager.addEventListener('playbackNotificationPlay', () =>
+        emitter.emit(Event.RemotePlay)
       ),
-      PlaybackNotificationManager.addEventListener(
-        'playbackNotificationPause',
-        () => emitter.emit(Event.RemotePause)
+      PlaybackNotificationManager.addEventListener('playbackNotificationPause', () =>
+        emitter.emit(Event.RemotePause)
       ),
       // Note: RNAP has no 'stop' notification event. RemoteStop is not wired
       // here — it fires only from app-level calls to TrackPlayer.stop().
-      PlaybackNotificationManager.addEventListener(
-        'playbackNotificationNext',
-        () => emitter.emit(Event.RemoteNext)
+      PlaybackNotificationManager.addEventListener('playbackNotificationNext', () =>
+        emitter.emit(Event.RemoteNext)
       ),
-      PlaybackNotificationManager.addEventListener(
-        'playbackNotificationPrevious',
-        () => emitter.emit(Event.RemotePrevious)
+      PlaybackNotificationManager.addEventListener('playbackNotificationPrevious', () =>
+        emitter.emit(Event.RemotePrevious)
       ),
       PlaybackNotificationManager.addEventListener(
         'playbackNotificationSeekTo',
@@ -93,7 +93,7 @@ export class NotificationBridge {
   }
 
   teardown(): void {
-    this.subscriptions.forEach(s => s.remove());
+    this.subscriptions.forEach((s) => s.remove());
     this.subscriptions = [];
     this.isSetup = false;
     this.appliedControls.clear();
@@ -112,15 +112,10 @@ export class NotificationBridge {
    * iOS note: elapsedTime does NOT update automatically — it must be set
    * manually on each state change, which is why we require `position` here.
    */
-  async updateNowPlaying(
-    track: Track,
-    state: State,
-    position: number
-  ): Promise<void> {
+  async updateNowPlaying(track: Track, state: State, position: number): Promise<void> {
     if (!this.isSetup) return;
 
-    const notifState: 'playing' | 'paused' =
-      state === State.Playing ? 'playing' : 'paused';
+    const notifState: 'playing' | 'paused' = state === State.Playing ? 'playing' : 'paused';
 
     await PlaybackNotificationManager.show({
       title: track.title,

--- a/src/QueueManager.ts
+++ b/src/QueueManager.ts
@@ -34,19 +34,19 @@ export class QueueManager {
    */
   remove(indexOrIndices: number | number[] | Track | Track[]): void {
     // Resolve any Track objects to their queue indices
-    const resolved = (Array.isArray(indexOrIndices) ? indexOrIndices : [indexOrIndices]).map(
-      (item): number => {
+    const resolved = (Array.isArray(indexOrIndices) ? indexOrIndices : [indexOrIndices])
+      .map((item): number => {
         if (typeof item === 'number') return item;
         // Track object — find by URL
-        const idx = this.queue.findIndex(t => t.url === item.url);
+        const idx = this.queue.findIndex((t) => t.url === item.url);
         return idx; // -1 if not found; will be filtered below
-      }
-    ).filter(i => i >= 0);
+      })
+      .filter((i) => i >= 0);
 
     const indices = new Set(resolved);
 
     const removingCurrent = indices.has(this.currentIndex);
-    const removedBefore = [...indices].filter(i => i < this.currentIndex).length;
+    const removedBefore = [...indices].filter((i) => i < this.currentIndex).length;
 
     this.queue = this.queue.filter((_, i) => !indices.has(i));
 
@@ -54,10 +54,7 @@ export class QueueManager {
       this.currentIndex = -1;
     } else if (removingCurrent) {
       // Land on the track that slid into the current slot, or clamp to last
-      this.currentIndex = Math.min(
-        this.currentIndex - removedBefore,
-        this.queue.length - 1
-      );
+      this.currentIndex = Math.min(this.currentIndex - removedBefore, this.queue.length - 1);
     } else {
       this.currentIndex -= removedBefore;
     }
@@ -127,5 +124,4 @@ export class QueueManager {
   getActiveIndex(): number {
     return this.currentIndex;
   }
-
 }

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -17,6 +17,7 @@ import { emitter } from './EventEmitter';
 import { _registerProgressGetters } from './hooks/useProgress';
 import { _registerActiveTrackGetter } from './hooks/useActiveTrack';
 import { _registerStateGetter } from './hooks/usePlaybackState';
+import { _registerQueueGetter } from './hooks/useQueue';
 
 // ---------------------------------------------------------------------------
 // Module-level singletons
@@ -36,6 +37,7 @@ _registerStateGetter(() => engine.getState());
 
 // Wire active-track getter into useActiveTrack without creating circular imports
 _registerActiveTrackGetter(() => queue.getActiveTrack() ?? null);
+_registerQueueGetter(() => queue.getQueue());
 
 // Wire auto-advance: when a track ends naturally, move to the next one.
 // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/src/TrackPlayer.ts
+++ b/src/TrackPlayer.ts
@@ -94,6 +94,10 @@ engine.onTrackEnded(async () => {
 // TrackPlayer public API
 // ---------------------------------------------------------------------------
 
+function emitQueueChanged(): void {
+  emitter.emit(Event.QueueChanged, queue.getQueue());
+}
+
 const TrackPlayer = {
   /**
    * Tear down the player completely — stops playback, clears the queue, destroys
@@ -151,11 +155,13 @@ const TrackPlayer = {
   async setQueue(tracks: Track[]): Promise<void> {
     await engine.stop();
     queue.setQueue(tracks);
+    emitQueueChanged();
   },
 
   /** Append tracks to the end of the queue. */
   add(tracks: Track[]): void {
     queue.add(tracks);
+    emitQueueChanged();
   },
 
   /**
@@ -164,6 +170,7 @@ const TrackPlayer = {
    */
   remove(indexOrIndices: number | number[] | Track | Track[]): void {
     queue.remove(indexOrIndices);
+    emitQueueChanged();
   },
 
   getQueue(): readonly Track[] {
@@ -192,6 +199,8 @@ const TrackPlayer = {
   async updateMetadataForTrack(index: number, metadata: TrackMetadata): Promise<void> {
     const updated = queue.updateTrack(index, metadata);
     if (!updated) return;
+
+    emitQueueChanged();
 
     // Only refresh the notification if this is the active track
     if (index === queue.getActiveIndex()) {

--- a/src/__mocks__/react-native-audio-api.ts
+++ b/src/__mocks__/react-native-audio-api.ts
@@ -203,11 +203,9 @@ export { MockAudioContext as AudioContext };
 // decodeAudioData
 // ---------------------------------------------------------------------------
 
-export const decodeAudioData = jest.fn(
-  (_url: string): MockAudioBuffer => {
-    return new MockAudioBuffer(_nextDecodeDuration);
-  }
-);
+export const decodeAudioData = jest.fn((_url: string): MockAudioBuffer => {
+  return new MockAudioBuffer(_nextDecodeDuration);
+});
 
 // ---------------------------------------------------------------------------
 // PlaybackNotificationManager

--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -169,7 +169,12 @@ describe('loadAndPlay (streaming path)', () => {
     clearCreatedStreamers();
     // Override: createStreamer returns a node whose initialize returns false
     const ctx = getLastAudioContext()!;
-    const failNode = { connect: jest.fn(), initialize: jest.fn().mockReturnValue(false), start: jest.fn(), stop: jest.fn() };
+    const failNode = {
+      connect: jest.fn(),
+      initialize: jest.fn().mockReturnValue(false),
+      start: jest.fn(),
+      stop: jest.fn(),
+    };
     jest.spyOn(ctx, 'createStreamer').mockReturnValueOnce(failNode as any);
     await expect(patchedEngine.loadAndPlay(makeTrack())).rejects.toThrow('failed to initialize');
     expect(patchedEngine.getState()).toBe(State.Error);
@@ -303,10 +308,10 @@ describe('pause / resume', () => {
     const ctx = getLastAudioContext()!;
 
     ctx.advanceTime(5);
-    await engine.pause();        // pausedPosition = 5
-    ctx.advanceTime(100);        // time passes while paused (should not count)
+    await engine.pause(); // pausedPosition = 5
+    ctx.advanceTime(100); // time passes while paused (should not count)
     await engine.resume();
-    ctx.advanceTime(3);          // 3 more seconds of play after resume
+    ctx.advanceTime(3); // 3 more seconds of play after resume
 
     expect(engine.getPosition()).toBeCloseTo(8, 4);
   });

--- a/src/__tests__/QueueManager.test.ts
+++ b/src/__tests__/QueueManager.test.ts
@@ -75,25 +75,25 @@ describe('remove', () => {
   it('removes a single track by index', () => {
     const q = makeQueue(1, 2, 3);
     q.remove(1);
-    expect(q.getQueue().map(t => t.title)).toEqual(['Track 1', 'Track 3']);
+    expect(q.getQueue().map((t) => t.title)).toEqual(['Track 1', 'Track 3']);
   });
 
   it('removes multiple tracks by index array', () => {
     const q = makeQueue(1, 2, 3, 4);
     q.remove([0, 2]);
-    expect(q.getQueue().map(t => t.title)).toEqual(['Track 2', 'Track 4']);
+    expect(q.getQueue().map((t) => t.title)).toEqual(['Track 2', 'Track 4']);
   });
 
   it('removes a track by Track object (matched by URL)', () => {
     const q = makeQueue(1, 2, 3);
     q.remove(track(2));
-    expect(q.getQueue().map(t => t.title)).toEqual(['Track 1', 'Track 3']);
+    expect(q.getQueue().map((t) => t.title)).toEqual(['Track 1', 'Track 3']);
   });
 
   it('adjusts active index down when a track before current is removed', () => {
     const q = makeQueue(1, 2, 3);
     q.skipToNext(); // index 1 (Track 2)
-    q.remove(0);   // remove Track 1
+    q.remove(0); // remove Track 1
     expect(q.getActiveIndex()).toBe(0);
     expect(q.getActiveTrack()?.title).toBe('Track 2');
   });
@@ -240,7 +240,6 @@ describe('updateTrack', () => {
   });
 });
 
-
 // ---------------------------------------------------------------------------
 // Edge cases — add() with insertBeforeIndex (issue #4)
 // ---------------------------------------------------------------------------
@@ -251,7 +250,7 @@ describe('add — insertBeforeIndex edge cases', () => {
     // No insertBeforeIndex support in current API — add() always appends.
     // This test documents the expected append-only behaviour.
     q.add([track(3)]);
-    expect(q.getQueue().map(t => t.title)).toEqual(['Track 1', 'Track 2', 'Track 3']);
+    expect(q.getQueue().map((t) => t.title)).toEqual(['Track 1', 'Track 2', 'Track 3']);
   });
 
   it('adding to a full queue beyond its length appends correctly', () => {

--- a/src/__tests__/TrackPlayer.test.ts
+++ b/src/__tests__/TrackPlayer.test.ts
@@ -69,6 +69,17 @@ describe('updateOptions', () => {
 // ---------------------------------------------------------------------------
 
 describe('setQueue', () => {
+  it('emits QueueChanged with the new queue', async () => {
+    await setup();
+    const handler = jest.fn();
+    TrackPlayer.addEventListener(Event.QueueChanged, handler);
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    expect(handler).toHaveBeenCalledWith([
+      expect.objectContaining({ title: 'Track 1' }),
+      expect.objectContaining({ title: 'Track 2' }),
+    ]);
+  });
+
   it('does NOT begin playback — state is Stopped after setQueue alone', async () => {
     await setup();
     await TrackPlayer.setQueue([track(1), track(2)]);
@@ -139,12 +150,37 @@ describe('setQueue', () => {
 // ---------------------------------------------------------------------------
 
 describe('add / remove / getQueue / getTrack', () => {
+  it('add emits QueueChanged with the appended queue', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1)]);
+    const handler = jest.fn();
+    TrackPlayer.addEventListener(Event.QueueChanged, handler);
+    TrackPlayer.add([track(2), track(3)]);
+    expect(handler).toHaveBeenCalledWith([
+      expect.objectContaining({ title: 'Track 1' }),
+      expect.objectContaining({ title: 'Track 2' }),
+      expect.objectContaining({ title: 'Track 3' }),
+    ]);
+  });
+
   it('add appends tracks to the queue', async () => {
     await setup();
     await TrackPlayer.setQueue([track(1)]);
     TrackPlayer.add([track(2), track(3)]);
     const q = TrackPlayer.getQueue();
     expect(q).toHaveLength(3);
+  });
+
+  it('remove emits QueueChanged with the filtered queue', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1), track(2), track(3)]);
+    const handler = jest.fn();
+    TrackPlayer.addEventListener(Event.QueueChanged, handler);
+    TrackPlayer.remove([1]);
+    expect(handler).toHaveBeenCalledWith([
+      expect.objectContaining({ title: 'Track 1' }),
+      expect.objectContaining({ title: 'Track 3' }),
+    ]);
   });
 
   it('remove removes a track by index', async () => {
@@ -472,6 +508,18 @@ describe('addEventListener', () => {
 // ---------------------------------------------------------------------------
 
 describe('updateMetadataForTrack', () => {
+  it('emits QueueChanged with the patched queue', async () => {
+    await setup();
+    await TrackPlayer.setQueue([track(1), track(2)]);
+    const handler = jest.fn();
+    TrackPlayer.addEventListener(Event.QueueChanged, handler);
+    await TrackPlayer.updateMetadataForTrack(1, { title: 'Patched' });
+    expect(handler).toHaveBeenCalledWith([
+      expect.objectContaining({ title: 'Track 1' }),
+      expect.objectContaining({ title: 'Patched' }),
+    ]);
+  });
+
   it('patches the stored track in the queue', async () => {
     await setup();
     await TrackPlayer.setQueue([track(1), track(2)]);

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -19,6 +19,7 @@ import { emitter } from '../EventEmitter';
 import { _registerProgressGetters, useProgress } from '../hooks/useProgress';
 import { usePlaybackState } from '../hooks/usePlaybackState';
 import { _registerActiveTrackGetter } from '../hooks/useActiveTrack';
+import { _registerQueueGetter, useQueue } from '../hooks/useQueue';
 
 // ---------------------------------------------------------------------------
 // Reset
@@ -305,6 +306,75 @@ describe('useActiveTrack — _registerActiveTrackGetter', () => {
   it('accepts a getter that returns a track', () => {
     const track = { id: '1', url: 'https://example.com/a.mp3', title: 'Track A' };
     expect(() => _registerActiveTrackGetter(() => track)).not.toThrow();
+  });
+});
+
+describe('useQueue — _registerQueueGetter', () => {
+  it('accepts a getter function without throwing', () => {
+    expect(() => _registerQueueGetter(() => [])).not.toThrow();
+  });
+
+  it('accepts a getter that returns a queue', () => {
+    const queue = [{ id: '1', url: 'https://example.com/a.mp3', title: 'Track A' }];
+    expect(() => _registerQueueGetter(() => queue)).not.toThrow();
+  });
+
+  it('hook export is a function (smoke test)', () => {
+    expect(typeof useQueue).toBe('function');
+  });
+});
+
+describe('useQueue — QueueChanged subscription', () => {
+  it('emits updated queue via QueueChanged', () => {
+    const received: Array<readonly { title?: string }[]> = [];
+
+    const unsub = emitter.on(Event.QueueChanged, (payload: any) => {
+      received.push(payload);
+    });
+
+    emitter.emit(Event.QueueChanged, [
+      { id: '1', url: 'https://example.com/a.mp3', title: 'Track A' },
+      { id: '2', url: 'https://example.com/b.mp3', title: 'Track B' },
+    ]);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.map((track) => track.title)).toEqual(['Track A', 'Track B']);
+
+    unsub();
+  });
+
+  it('emits an empty queue when cleared', () => {
+    const received: Array<readonly unknown[]> = [];
+
+    const unsub = emitter.on(Event.QueueChanged, (payload: any) => {
+      received.push(payload);
+    });
+
+    emitter.emit(Event.QueueChanged, []);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual([]);
+
+    unsub();
+  });
+
+  it('tracks multiple successive queue changes in order', () => {
+    const lengths: number[] = [];
+
+    const unsub = emitter.on(Event.QueueChanged, (payload: any) => {
+      lengths.push(payload.length);
+    });
+
+    emitter.emit(Event.QueueChanged, [{ url: 'https://example.com/a.mp3', title: 'A' }]);
+    emitter.emit(Event.QueueChanged, [
+      { url: 'https://example.com/a.mp3', title: 'A' },
+      { url: 'https://example.com/b.mp3', title: 'B' },
+    ]);
+    emitter.emit(Event.QueueChanged, []);
+
+    expect(lengths).toEqual([1, 2, 0]);
+
+    unsub();
   });
 });
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -16,10 +16,7 @@
 
 import { Event, State } from '../types';
 import { emitter } from '../EventEmitter';
-import {
-  _registerProgressGetters,
-  useProgress,
-} from '../hooks/useProgress';
+import { _registerProgressGetters, useProgress } from '../hooks/useProgress';
 import { usePlaybackState } from '../hooks/usePlaybackState';
 import { _registerActiveTrackGetter } from '../hooks/useActiveTrack';
 
@@ -110,7 +107,11 @@ describe('useProgress — getter registration', () => {
     expect(typeof _registerProgressGetters).toBe('function');
     // Should not throw
     expect(() =>
-      _registerProgressGetters(() => 0, () => 0, () => State.None),
+      _registerProgressGetters(
+        () => 0,
+        () => 0,
+        () => State.None
+      )
     ).not.toThrow();
   });
 
@@ -298,16 +299,12 @@ describe('useProgress — polling interval', () => {
 
 describe('useActiveTrack — _registerActiveTrackGetter', () => {
   it('accepts a getter function without throwing', () => {
-    expect(() =>
-      _registerActiveTrackGetter(() => null),
-    ).not.toThrow();
+    expect(() => _registerActiveTrackGetter(() => null)).not.toThrow();
   });
 
   it('accepts a getter that returns a track', () => {
     const track = { id: '1', url: 'https://example.com/a.mp3', title: 'Track A' };
-    expect(() =>
-      _registerActiveTrackGetter(() => track),
-    ).not.toThrow();
+    expect(() => _registerActiveTrackGetter(() => track)).not.toThrow();
   });
 });
 
@@ -362,9 +359,24 @@ describe('useActiveTrack — PlaybackActiveTrackChanged subscription', () => {
       titles.push(payload.track?.title ?? null);
     });
 
-    emitter.emit(Event.PlaybackActiveTrackChanged, { track: trackA, index: 0, lastTrack: null, lastIndex: -1 });
-    emitter.emit(Event.PlaybackActiveTrackChanged, { track: trackB, index: 1, lastTrack: trackA, lastIndex: 0 });
-    emitter.emit(Event.PlaybackActiveTrackChanged, { track: null, index: -1, lastTrack: trackB, lastIndex: 1 });
+    emitter.emit(Event.PlaybackActiveTrackChanged, {
+      track: trackA,
+      index: 0,
+      lastTrack: null,
+      lastIndex: -1,
+    });
+    emitter.emit(Event.PlaybackActiveTrackChanged, {
+      track: trackB,
+      index: 1,
+      lastTrack: trackA,
+      lastIndex: 0,
+    });
+    emitter.emit(Event.PlaybackActiveTrackChanged, {
+      track: null,
+      index: -1,
+      lastTrack: trackB,
+      lastIndex: 1,
+    });
 
     expect(titles).toEqual(['A', 'B', null]);
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -69,7 +69,7 @@ function lastSource() {
 /** Flush pending microtasks and macrotasks. */
 async function flushAsync(rounds = 3): Promise<void> {
   for (let i = 0; i < rounds; i++) {
-    await new Promise<void>(r => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
   }
 }
 
@@ -102,11 +102,9 @@ describe('Scenario 1: full single-track lifecycle (streaming path)', () => {
 
     const events: string[] = [];
     TrackPlayer.addEventListener(Event.PlaybackActiveTrackChanged, () =>
-      events.push('trackChanged'),
+      events.push('trackChanged')
     );
-    TrackPlayer.addEventListener(Event.PlaybackState, (e) =>
-      events.push(`state:${e.state}`),
-    );
+    TrackPlayer.addEventListener(Event.PlaybackState, (e) => events.push(`state:${e.state}`));
 
     await TrackPlayer.setQueue([track(1, 120)]);
     await TrackPlayer.play();
@@ -115,19 +113,19 @@ describe('Scenario 1: full single-track lifecycle (streaming path)', () => {
     expect(events).toContain('trackChanged');
 
     await TrackPlayer.seekTo(45);
-    expect((TrackPlayer.getPlaybackState()).position).toBeCloseTo(45, 3);
+    expect(TrackPlayer.getPlaybackState().position).toBeCloseTo(45, 3);
 
     await TrackPlayer.pause();
     expect(TrackPlayer.getPlaybackState()).toMatchObject({ state: State.Paused });
 
     getLastAudioContext()!.advanceTime(30);
-    expect((TrackPlayer.getPlaybackState()).position).toBeCloseTo(45, 3);
+    expect(TrackPlayer.getPlaybackState().position).toBeCloseTo(45, 3);
 
     await TrackPlayer.play();
     expect(TrackPlayer.getPlaybackState()).toMatchObject({ state: State.Playing });
 
     getLastAudioContext()!.advanceTime(10);
-    expect((TrackPlayer.getPlaybackState()).position).toBeCloseTo(55, 3);
+    expect(TrackPlayer.getPlaybackState().position).toBeCloseTo(55, 3);
 
     triggerStreamerEnd(120);
     await flushAsync();
@@ -213,13 +211,13 @@ describe('Scenario 3: full single-track lifecycle (buffer fallback path)', () =>
     expect(TrackPlayer.getPlaybackState()).toMatchObject({ state: State.Paused });
 
     await TrackPlayer.seekTo(30);
-    expect((TrackPlayer.getPlaybackState()).position).toBeCloseTo(30, 3);
+    expect(TrackPlayer.getPlaybackState().position).toBeCloseTo(30, 3);
 
     await TrackPlayer.play();
     expect(TrackPlayer.getPlaybackState()).toMatchObject({ state: State.Playing });
 
     getLastAudioContext()!.advanceTime(15);
-    expect((TrackPlayer.getPlaybackState()).position).toBeCloseTo(45, 3);
+    expect(TrackPlayer.getPlaybackState().position).toBeCloseTo(45, 3);
 
     const progress = TrackPlayer.getProgress();
     expect(progress.duration).toBe(90);
@@ -314,19 +312,19 @@ describe('Scenario 5: notification lifecycle across a full session', () => {
     await TrackPlayer.play();
 
     expect(PlaybackNotificationManager.show).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Track 1' }),
+      expect.objectContaining({ title: 'Track 1' })
     );
 
     jest.clearAllMocks();
     await TrackPlayer.seekTo(30);
     expect(PlaybackNotificationManager.show).toHaveBeenCalledWith(
-      expect.objectContaining({ elapsedTime: 30 }),
+      expect.objectContaining({ elapsedTime: 30 })
     );
 
     jest.clearAllMocks();
     await TrackPlayer.updateMetadataForTrack(0, { artwork: 'https://example.com/cover.jpg' });
     expect(PlaybackNotificationManager.show).toHaveBeenCalledWith(
-      expect.objectContaining({ artwork: 'https://example.com/cover.jpg' }),
+      expect.objectContaining({ artwork: 'https://example.com/cover.jpg' })
     );
 
     jest.clearAllMocks();
@@ -341,7 +339,7 @@ describe('Scenario 5: notification lifecycle across a full session', () => {
     await TrackPlayer.play();
 
     expect(PlaybackNotificationManager.show).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Track 1' }),
+      expect.objectContaining({ title: 'Track 1' })
     );
 
     jest.clearAllMocks();
@@ -349,7 +347,7 @@ describe('Scenario 5: notification lifecycle across a full session', () => {
     await flushAsync();
 
     expect(PlaybackNotificationManager.show).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Track 2' }),
+      expect.objectContaining({ title: 'Track 2' })
     );
 
     jest.clearAllMocks();
@@ -393,7 +391,7 @@ describe('Scenario 6: skipToPrevious / skipToNext edge cases', () => {
     await TrackPlayer.skipToPrevious();
 
     expect(TrackPlayer.getActiveTrack()).toMatchObject({ title: 'Track 2' });
-    expect((TrackPlayer.getPlaybackState()).position).toBeCloseTo(0, 3);
+    expect(TrackPlayer.getPlaybackState().position).toBeCloseTo(0, 3);
   });
 
   it('skip forward then backward then forward emits the correct track-changed events', async () => {
@@ -516,7 +514,7 @@ describe('Bug #9: silent error swallow on auto-advance', () => {
     await TrackPlayer.play();
 
     const errors: unknown[] = [];
-    TrackPlayer.addEventListener(Event.PlaybackError, payload => {
+    TrackPlayer.addEventListener(Event.PlaybackError, (payload) => {
       errors.push(payload);
     });
 

--- a/src/hooks/useActiveTrack.ts
+++ b/src/hooks/useActiveTrack.ts
@@ -37,7 +37,7 @@ export function useActiveTrack(): Track | null {
   const [track, setTrack] = useState<Track | null>(
     // Snapshot current track on mount if the getter is already registered.
     // Avoids a stale null flash when the hook mounts mid-playback.
-    _isSetup ? _getActiveTrack() : null,
+    _isSetup ? _getActiveTrack() : null
   );
 
   useEffect(() => {

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -74,10 +74,8 @@ export function useProgress(updateInterval = 1000): Progress {
       if (isPlaying) {
         const position = _getPosition();
         const duration = _getDuration();
-        setProgress(prev =>
-          prev.position === position && prev.duration === duration
-            ? prev
-            : { position, duration }
+        setProgress((prev) =>
+          prev.position === position && prev.duration === duration ? prev : { position, duration }
         );
       }
     });

--- a/src/hooks/useQueue.ts
+++ b/src/hooks/useQueue.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { emitter } from '../EventEmitter';
+import { Event, Track } from '../types';
+
+/**
+ * Module-level getter reference, populated by TrackPlayer via
+ * _registerQueueGetter() to avoid circular imports.
+ */
+let _getQueue: () => readonly Track[] = () => [];
+
+/** True once TrackPlayer has registered the getter. */
+let _isSetup = false;
+
+/**
+ * Called once during TrackPlayer initialization to wire up the queue getter.
+ * Not part of the public API.
+ */
+export function _registerQueueGetter(getter: () => readonly Track[]): void {
+  _getQueue = getter;
+  _isSetup = true;
+}
+
+/**
+ * Returns the current queue and re-renders automatically whenever queue
+ * mutations occur.
+ */
+export function useQueue(): readonly Track[] {
+  const [queue, setQueue] = useState<readonly Track[]>(() => (_isSetup ? _getQueue() : []));
+
+  useEffect(() => {
+    if (_isSetup) {
+      setQueue(_getQueue());
+    }
+
+    const unsub = emitter.on(Event.QueueChanged, (payload) => {
+      setQueue(payload as readonly Track[]);
+    });
+
+    return unsub;
+  }, []);
+
+  return queue;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * A React Native audio playback library built on react-native-audio-api.
  *
  * Usage:
- *   import TrackPlayer, { State, Event, Capability, usePlaybackState, useProgress, useActiveTrack }
+ *   import TrackPlayer, { State, Event, Capability, usePlaybackState, useProgress, useActiveTrack, useQueue }
  *     from 'react-native-track-playback';
  */
 
@@ -31,3 +31,4 @@ export { State, Event, Capability, PlaybackError } from './types';
 export { usePlaybackState } from './hooks/usePlaybackState';
 export { useProgress } from './hooks/useProgress';
 export { useActiveTrack } from './hooks/useActiveTrack';
+export { useQueue } from './hooks/useQueue';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,18 @@ export { default } from './TrackPlayer';
 
 // Named exports
 
-
 // Types & enums
-export type { Track, TrackMetadata, PlaybackState, Progress, UpdateOptions, ActiveTrackChangedEvent, RemoteSeekEvent, EventPayloadMap, Subscription } from './types';
+export type {
+  Track,
+  TrackMetadata,
+  PlaybackState,
+  Progress,
+  UpdateOptions,
+  ActiveTrackChangedEvent,
+  RemoteSeekEvent,
+  EventPayloadMap,
+  Subscription,
+} from './types';
 export { State, Event, Capability, PlaybackError } from './types';
 
 // React hooks

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,35 +17,36 @@ export interface Track {
 export type TrackMetadata = Omit<Track, 'url'>;
 
 export enum State {
-  None      = 'none',
-  Loading   = 'loading',
+  None = 'none',
+  Loading = 'loading',
   Buffering = 'buffering',
-  Playing   = 'playing',
-  Paused    = 'paused',
-  Stopped   = 'stopped',
-  Ended     = 'ended',
-  Error     = 'error',
+  Playing = 'playing',
+  Paused = 'paused',
+  Stopped = 'stopped',
+  Ended = 'ended',
+  Error = 'error',
 }
 
 export enum Event {
-  PlaybackState              = 'playback-state',
-  PlaybackError              = 'playback-error',
+  PlaybackState = 'playback-state',
+  PlaybackError = 'playback-error',
   PlaybackActiveTrackChanged = 'playback-active-track-changed',
-  RemotePlay                 = 'remote-play',
-  RemotePause                = 'remote-pause',
-  RemoteStop                 = 'remote-stop',
-  RemoteNext                 = 'remote-next',
-  RemotePrevious             = 'remote-previous',
-  RemoteSeek                 = 'remote-seek',
+  QueueChanged = 'queue-changed',
+  RemotePlay = 'remote-play',
+  RemotePause = 'remote-pause',
+  RemoteStop = 'remote-stop',
+  RemoteNext = 'remote-next',
+  RemotePrevious = 'remote-previous',
+  RemoteSeek = 'remote-seek',
 }
 
 export enum Capability {
-  Play           = 'play',
-  Pause          = 'pause',
-  Stop           = 'stop',
-  SkipToNext     = 'skip-to-next',
+  Play = 'play',
+  Pause = 'pause',
+  Stop = 'stop',
+  SkipToNext = 'skip-to-next',
   SkipToPrevious = 'skip-to-previous',
-  SeekTo         = 'seek-to',
+  SeekTo = 'seek-to',
 }
 
 export interface PlaybackState {
@@ -87,7 +88,7 @@ export interface UpdateOptions {
 export class PlaybackError extends Error {
   constructor(
     message: string,
-    public readonly code: number,
+    public readonly code: number
   ) {
     super(message);
     this.name = 'PlaybackError';
@@ -108,6 +109,7 @@ export interface EventPayloadMap {
   [Event.PlaybackState]: PlaybackState;
   [Event.PlaybackError]: PlaybackError;
   [Event.PlaybackActiveTrackChanged]: ActiveTrackChangedEvent;
+  [Event.QueueChanged]: readonly Track[];
   [Event.RemotePlay]: void;
   [Event.RemotePause]: void;
   [Event.RemoteNext]: void;


### PR DESCRIPTION
## Summary
- add a reactive `useQueue` hook that initializes from the current queue and updates on `Event.QueueChanged`
- register a queue getter from `TrackPlayer` and export the hook from the package entrypoint
- add queue hook coverage and keep queue-changed emissions wired to queue mutations

## Testing
- npm test -- --runInBand

Closes #48