### PR TITLE
test: inject thin audio context interface

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -1,13 +1,14 @@
+import { Event, State, Track, PlaybackError } from './types';
+import { emitter } from './EventEmitter';
 import {
-  AudioContext,
-  decodeAudioData,
+  playbackAudioApi,
   type AudioBufferSourceNode,
   type GainNode,
   type AudioBuffer,
   type StreamerNode,
-} from 'react-native-audio-api';
-import { Event, State, Track, PlaybackError } from './types';
-import { emitter } from './EventEmitter';
+  type PlaybackAudioApi,
+  type PlaybackAudioContext,
+} from './audioContext';
 
 /**
  * PlaybackEngine owns the AudioContext and source node lifecycle.
@@ -55,7 +56,7 @@ import { emitter } from './EventEmitter';
  *   corrupt the engine state.
  */
 export class PlaybackEngine {
-  private context: AudioContext | null = null;
+  private context: PlaybackAudioContext | null = null;
   private gainNode: GainNode | null = null;
 
   // --- AudioBufferSourceNode path (decodeAudioData fallback) ---
@@ -101,13 +102,15 @@ export class PlaybackEngine {
   /** Interval handle for the StreamerNode track-end poller. */
   private streamerPollTimer: ReturnType<typeof setInterval> | null = null;
 
+  constructor(private readonly audioApi: PlaybackAudioApi = playbackAudioApi) {}
+
   // ---------------------------------------------------------------------------
   // Lifecycle
   // ---------------------------------------------------------------------------
 
   init(): void {
     if (this.context) return; // idempotent
-    this.context = new AudioContext();
+    this.context = this.audioApi.createContext();
     this.gainNode = this.context.createGain();
     this.gainNode.connect(this.context.destination);
 
@@ -265,7 +268,7 @@ export class PlaybackEngine {
       this.prefetchBuffer = null;
       this.prefetchUrl = null;
     } else {
-      buffer = await decodeAudioData(track.url);
+      buffer = await this.audioApi.decode(track.url);
 
       // A newer loadAndPlay() fired while we were downloading — discard the
       // decoded buffer and exit. The newer load has already taken ownership.
@@ -396,7 +399,7 @@ export class PlaybackEngine {
 
     if (!this.context || track.url === this.prefetchUrl) return;
     try {
-      const buffer = await decodeAudioData(track.url);
+      const buffer = await this.audioApi.decode(track.url);
       this.prefetchBuffer = buffer;
       this.prefetchUrl = track.url;
     } catch {

--- a/src/__tests__/PlaybackEngine.test.ts
+++ b/src/__tests__/PlaybackEngine.test.ts
@@ -1,20 +1,96 @@
 import { PlaybackEngine } from '../PlaybackEngine';
 import { State } from '../types';
-import {
-  getLastAudioContext,
-  getCreatedStreamers,
-  getCreatedSources,
-  clearCreatedStreamers,
-  clearCreatedSources,
-  setStreamerAvailable,
-  setNextDecodeDuration,
-  decodeAudioData,
-  MockAudioContext,
-} from '../__mocks__/react-native-audio-api';
+import type {
+  AudioBuffer,
+  AudioBufferSourceNode,
+  GainNode,
+  PlaybackAudioApi,
+  PlaybackAudioContext,
+  StreamerNode,
+} from '../audioContext';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+type TestDestination = PlaybackAudioContext['destination'];
+
+class TestAudioBuffer {
+  readonly numberOfChannels = 2;
+  readonly sampleRate = 44100;
+  readonly length: number;
+
+  constructor(public readonly duration: number) {
+    this.length = Math.floor(duration * this.sampleRate);
+  }
+}
+
+class TestGainNode implements Partial<GainNode> {
+  connect = jest.fn();
+  disconnect = jest.fn();
+}
+
+class TestAudioBufferSourceNode {
+  buffer: AudioBuffer | null = null;
+  connect = jest.fn();
+  disconnect = jest.fn();
+  start = jest.fn();
+  stop = jest.fn();
+  onEnded?: (...args: unknown[]) => void;
+
+  simulateEnded(): void {
+    this.onEnded?.();
+  }
+}
+
+class TestStreamerNode {
+  connect = jest.fn();
+  disconnect = jest.fn();
+  initialize = jest.fn().mockReturnValue(true);
+  start = jest.fn();
+  stop = jest.fn();
+}
+
+class TestAudioContext implements PlaybackAudioContext {
+  state: 'running' | 'suspended' | 'closed' = 'running';
+  currentTime = 0;
+  readonly destination = {} as TestDestination;
+  readonly gainNode = new TestGainNode();
+  readonly createdStreamers: TestStreamerNode[] = [];
+  readonly createdSources: TestAudioBufferSourceNode[] = [];
+  streamerAvailable = true;
+
+  advanceTime(seconds: number): void {
+    this.currentTime += seconds;
+  }
+
+  createGain(): GainNode {
+    return this.gainNode as unknown as GainNode;
+  }
+
+  createBufferSource(): AudioBufferSourceNode {
+    const node = new TestAudioBufferSourceNode();
+    this.createdSources.push(node);
+    return node as unknown as AudioBufferSourceNode;
+  }
+
+  createStreamer(): StreamerNode | null {
+    if (!this.streamerAvailable) return null;
+    const node = new TestStreamerNode();
+    this.createdStreamers.push(node);
+    return node as unknown as StreamerNode;
+  }
+
+  suspend(): boolean {
+    this.state = 'suspended';
+    return true;
+  }
+
+  resume(): boolean {
+    this.state = 'running';
+    return true;
+  }
+
+  close(): void {
+    this.state = 'closed';
+  }
+}
 
 function makeTrack(n = 1, duration = 30) {
   return {
@@ -24,312 +100,245 @@ function makeTrack(n = 1, duration = 30) {
   };
 }
 
-function makeEngine(): PlaybackEngine {
-  const engine = new PlaybackEngine();
-  engine.init();
-  return engine;
-}
+function makeEngine(options?: {
+  streamerAvailable?: boolean;
+  decodeDuration?: number;
+  decodeImpl?: (url: string) => AudioBuffer | Promise<AudioBuffer>;
+}) {
+  const context = new TestAudioContext();
+  if (options?.streamerAvailable !== undefined) {
+    context.streamerAvailable = options.streamerAvailable;
+  }
 
-// ---------------------------------------------------------------------------
-// Reset per test
-// ---------------------------------------------------------------------------
+  const decode = jest.fn(
+    options?.decodeImpl ??
+      (() => new TestAudioBuffer(options?.decodeDuration ?? 30) as unknown as AudioBuffer)
+  );
+
+  const audioApi: PlaybackAudioApi = {
+    createContext: () => context,
+    decode,
+  };
+
+  const engine = new PlaybackEngine(audioApi);
+  engine.init();
+
+  return { engine, context, decode };
+}
 
 beforeEach(() => {
   jest.useFakeTimers();
-  clearCreatedStreamers();
-  clearCreatedSources();
-  setStreamerAvailable(true);
-  setNextDecodeDuration(30);
-  jest.clearAllMocks();
 });
 
 afterEach(() => {
   jest.useRealTimers();
 });
 
-// ---------------------------------------------------------------------------
-// init
-// ---------------------------------------------------------------------------
-
 describe('init', () => {
-  it('creates an AudioContext and probes for StreamerNode', () => {
-    const engine = new PlaybackEngine();
-    engine.init();
-    const ctx = getLastAudioContext()!;
-    expect(ctx).toBeInstanceOf(MockAudioContext);
+  it('creates an audio context and probes for StreamerNode', async () => {
+    const { engine, context } = makeEngine();
+    await engine.loadAndPlay(makeTrack());
+    expect(context.createdStreamers).toHaveLength(2);
   });
 
-  it('is idempotent — calling init twice does not create a second context', () => {
-    const engine = new PlaybackEngine();
+  it('is idempotent, calling init twice does not create a second context', () => {
+    const { engine, context } = makeEngine();
     engine.init();
-    const ctx1 = getLastAudioContext();
-    engine.init();
-    const ctx2 = getLastAudioContext();
-    expect(ctx1).toBe(ctx2);
-  });
-
-  it('sets streamingAvailable=true when createStreamer returns a node', () => {
-    setStreamerAvailable(true);
-    const engine = makeEngine();
-    // loadAndPlay should use the streamer path — a streamer will be created
-    return engine.loadAndPlay(makeTrack()).then(() => {
-      expect(getCreatedStreamers()).toHaveLength(
-        // 1 probe at init + 1 for playback = 2
-        2
-      );
-    });
+    expect((engine as any).context).toBe(context);
   });
 
   it('falls back to buffer path when createStreamer returns null', async () => {
-    setStreamerAvailable(false);
-    const engine = makeEngine();
+    const { engine, context, decode } = makeEngine({ streamerAvailable: false });
     await engine.loadAndPlay(makeTrack());
-    expect(getCreatedStreamers()).toHaveLength(0);
-    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(context.createdStreamers).toHaveLength(0);
+    expect(decode).toHaveBeenCalledTimes(1);
   });
 });
 
-// ---------------------------------------------------------------------------
-// StreamerNode path — loadAndPlay
-// ---------------------------------------------------------------------------
-
 describe('loadAndPlay (streaming path)', () => {
   it('transitions to Playing state', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     expect(engine.getState()).toBe(State.Playing);
   });
 
   it('calls streamer.initialize with the track URL', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     const track = makeTrack();
     await engine.loadAndPlay(track);
-    const streamers = getCreatedStreamers();
-    const streamer = streamers[streamers.length - 1]!;
+    const streamer = context.createdStreamers[context.createdStreamers.length - 1]!;
     expect(streamer.initialize).toHaveBeenCalledWith(track.url);
   });
 
   it('calls streamer.start(0)', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
-    const streamers = getCreatedStreamers();
-    const streamer = streamers[streamers.length - 1]!;
+    const streamer = context.createdStreamers[context.createdStreamers.length - 1]!;
     expect(streamer.start).toHaveBeenCalledWith(0);
   });
 
   it('uses track.duration as the reported duration', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await engine.loadAndPlay(makeTrack(1, 245));
     expect(engine.getDuration()).toBe(245);
   });
 
   it('resumes a suspended context before starting', async () => {
-    const engine = makeEngine();
-    const ctx = getLastAudioContext()!;
-    ctx.state = 'suspended';
+    const { engine, context } = makeEngine();
+    context.state = 'suspended';
     await engine.loadAndPlay(makeTrack());
-    expect(ctx.state).toBe('running');
+    expect(context.state).toBe('running');
   });
 
   it('appends timeOffset param when startOffset > 0', async () => {
-    const engine = makeEngine();
-    const track = makeTrack();
-    await engine.loadAndPlay(track, 60);
-    const streamers = getCreatedStreamers();
-    const streamer = streamers[streamers.length - 1]!;
+    const { engine, context } = makeEngine();
+    await engine.loadAndPlay(makeTrack(), 60);
+    const streamer = context.createdStreamers[context.createdStreamers.length - 1]!;
     const calledUrl: string = streamer.initialize.mock.calls[0][0];
     expect(calledUrl).toContain('timeOffset=60');
   });
 
-  it('does NOT append timeOffset when startOffset is 0', async () => {
-    const engine = makeEngine();
+  it('does not append timeOffset when startOffset is 0', async () => {
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack(), 0);
-    const streamers = getCreatedStreamers();
-    const streamer = streamers[streamers.length - 1]!;
+    const streamer = context.createdStreamers[context.createdStreamers.length - 1]!;
     const calledUrl: string = streamer.initialize.mock.calls[0][0];
     expect(calledUrl).not.toContain('timeOffset');
   });
 
   it('tears down the previous streamer before starting a new one', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack(1));
-    // Index 0 = probe node (created during init), index 1 = first playback node
-    const streamers = getCreatedStreamers();
-    const first = streamers[streamers.length - 1]!;
+    const first = context.createdStreamers[context.createdStreamers.length - 1]!;
     await engine.loadAndPlay(makeTrack(2));
     expect(first.stop).toHaveBeenCalled();
   });
 
   it('sets State.Error and re-throws when initialize returns false', async () => {
-    // const engine = makeEngine();
-    // Make the next streamer's initialize fail
-    // Temporarily patch via the probe-created streamer list
-    // by replacing initialize on the factory result
-    const patchedEngine = makeEngine();
-    clearCreatedStreamers();
-    // Override: createStreamer returns a node whose initialize returns false
-    const ctx = getLastAudioContext()!;
-    const failNode = {
-      connect: jest.fn(),
-      initialize: jest.fn().mockReturnValue(false),
-      start: jest.fn(),
-      stop: jest.fn(),
-    };
-    jest.spyOn(ctx, 'createStreamer').mockReturnValueOnce(failNode as any);
-    await expect(patchedEngine.loadAndPlay(makeTrack())).rejects.toThrow('failed to initialize');
-    expect(patchedEngine.getState()).toBe(State.Error);
+    const { engine, context } = makeEngine();
+    const failNode = new TestStreamerNode();
+    failNode.initialize.mockReturnValue(false);
+    context.createStreamer = jest.fn(() => failNode as unknown as StreamerNode);
+
+    await expect(engine.loadAndPlay(makeTrack())).rejects.toThrow('failed to initialize');
+    expect(engine.getState()).toBe(State.Error);
   });
 });
 
-// ---------------------------------------------------------------------------
-// Buffer fallback path — loadAndPlay
-// ---------------------------------------------------------------------------
-
 describe('loadAndPlay (buffer fallback path)', () => {
-  beforeEach(() => {
-    setStreamerAvailable(false);
-  });
-
-  it('calls decodeAudioData with the track URL', async () => {
-    const engine = makeEngine();
+  it('calls decode with the track URL', async () => {
+    const { engine, decode } = makeEngine({ streamerAvailable: false });
     const track = makeTrack();
     await engine.loadAndPlay(track);
-    expect(decodeAudioData).toHaveBeenCalledWith(track.url);
+    expect(decode).toHaveBeenCalledWith(track.url);
   });
 
-  it('transitions through Buffering → Playing', async () => {
-    const engine = makeEngine();
-    // const states: State[] = []; // removed — unused
-    // Patch setState indirectly by observing state at each promise tick
-    // (simpler: just assert final state and that decodeAudioData was awaited)
+  it('transitions to Playing', async () => {
+    const { engine } = makeEngine({ streamerAvailable: false });
     await engine.loadAndPlay(makeTrack());
     expect(engine.getState()).toBe(State.Playing);
   });
 
   it('uses buffer.duration as the reported duration', async () => {
-    setNextDecodeDuration(180);
-    const engine = makeEngine();
+    const { engine } = makeEngine({ streamerAvailable: false, decodeDuration: 180 });
     await engine.loadAndPlay(makeTrack());
     expect(engine.getDuration()).toBe(180);
   });
 
   it('uses the prefetch cache on a URL match', async () => {
-    const engine = makeEngine();
+    const { engine, decode } = makeEngine({ streamerAvailable: false });
     const track = makeTrack();
-    // Prefetch track first
     await engine.prefetchNext(track);
-    expect(decodeAudioData).toHaveBeenCalledTimes(1);
-    jest.clearAllMocks();
-    // loadAndPlay should hit the cache — no second decode
+    expect(decode).toHaveBeenCalledTimes(1);
+    decode.mockClear();
     await engine.loadAndPlay(track);
-    expect(decodeAudioData).not.toHaveBeenCalled();
+    expect(decode).not.toHaveBeenCalled();
   });
 
   it('does not use prefetch cache on URL mismatch', async () => {
-    const engine = makeEngine();
+    const { engine, decode } = makeEngine({ streamerAvailable: false });
     await engine.prefetchNext(makeTrack(1));
-    jest.clearAllMocks();
+    decode.mockClear();
     await engine.loadAndPlay(makeTrack(2));
-    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(decode).toHaveBeenCalledTimes(1);
   });
 });
-
-// ---------------------------------------------------------------------------
-// prefetchNext
-// ---------------------------------------------------------------------------
 
 describe('prefetchNext', () => {
   it('is a no-op when streaming is available', async () => {
-    setStreamerAvailable(true);
-    const engine = makeEngine();
+    const { engine, decode } = makeEngine();
     await engine.prefetchNext(makeTrack());
-    expect(decodeAudioData).not.toHaveBeenCalled();
+    expect(decode).not.toHaveBeenCalled();
   });
 
   it('decodes when streaming is unavailable', async () => {
-    setStreamerAvailable(false);
-    const engine = makeEngine();
+    const { engine, decode } = makeEngine({ streamerAvailable: false });
     await engine.prefetchNext(makeTrack());
-    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(decode).toHaveBeenCalledTimes(1);
   });
 
   it('skips re-fetch when the same URL is already prefetched', async () => {
-    setStreamerAvailable(false);
-    const engine = makeEngine();
+    const { engine, decode } = makeEngine({ streamerAvailable: false });
     const track = makeTrack();
     await engine.prefetchNext(track);
     await engine.prefetchNext(track);
-    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(decode).toHaveBeenCalledTimes(1);
   });
 });
 
-// ---------------------------------------------------------------------------
-// pause / resume
-// ---------------------------------------------------------------------------
-
 describe('pause / resume', () => {
   it('suspends the context and transitions to Paused', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     await engine.pause();
-    const ctx = getLastAudioContext()!;
-    expect(ctx.state).toBe('suspended');
+    expect(context.state).toBe('suspended');
     expect(engine.getState()).toBe(State.Paused);
   });
 
   it('snapshots position before suspending', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
-    const ctx = getLastAudioContext()!;
-    ctx.advanceTime(10);
+    context.advanceTime(10);
     await engine.pause();
     expect(engine.getPosition()).toBeCloseTo(10, 5);
   });
 
   it('is a no-op when not playing', async () => {
-    const engine = makeEngine();
-    await engine.pause(); // state is None
+    const { engine } = makeEngine();
+    await engine.pause();
     expect(engine.getState()).toBe(State.None);
   });
 
   it('resumes context and transitions to Playing', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     await engine.pause();
     await engine.resume();
-    const ctx = getLastAudioContext()!;
-    expect(ctx.state).toBe('running');
+    expect(context.state).toBe('running');
     expect(engine.getState()).toBe(State.Playing);
   });
 
-  it('position tracking remains correct after pause→resume→advance', async () => {
-    const engine = makeEngine();
+  it('position tracking remains correct after pause, resume, and advance', async () => {
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
-    const ctx = getLastAudioContext()!;
-
-    ctx.advanceTime(5);
-    await engine.pause(); // pausedPosition = 5
-    ctx.advanceTime(100); // time passes while paused (should not count)
+    context.advanceTime(5);
+    await engine.pause();
+    context.advanceTime(100);
     await engine.resume();
-    ctx.advanceTime(3); // 3 more seconds of play after resume
-
+    context.advanceTime(3);
     expect(engine.getPosition()).toBeCloseTo(8, 4);
   });
 
   it('is a no-op when not paused', async () => {
-    const engine = makeEngine();
-    await engine.resume(); // state is None
+    const { engine } = makeEngine();
+    await engine.resume();
     expect(engine.getState()).toBe(State.None);
   });
 });
 
-// ---------------------------------------------------------------------------
-// stop
-// ---------------------------------------------------------------------------
-
 describe('stop', () => {
   it('stops the source, resets duration and position, transitions to Stopped', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await engine.loadAndPlay(makeTrack(1, 120));
     await engine.stop();
     expect(engine.getState()).toBe(State.Stopped);
@@ -338,42 +347,37 @@ describe('stop', () => {
   });
 
   it('resumes a suspended context so the next loadAndPlay is not blocked', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     await engine.pause();
     await engine.stop();
-    const ctx = getLastAudioContext()!;
-    expect(ctx.state).toBe('running');
+    expect(context.state).toBe('running');
   });
 });
 
-// ---------------------------------------------------------------------------
-// seekTo — streaming path
-// ---------------------------------------------------------------------------
-
 describe('seekTo (streaming path)', () => {
   it('creates a new streamer with the timeOffset URL', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     const track = makeTrack();
     await engine.loadAndPlay(track);
-    clearCreatedStreamers();
+    context.createdStreamers.length = 0;
 
     await engine.seekTo(45);
 
-    const seekStreamer = getCreatedStreamers()[0]!;
+    const seekStreamer = context.createdStreamers[0]!;
     const calledUrl: string = seekStreamer.initialize.mock.calls[0][0];
     expect(calledUrl).toContain('timeOffset=45');
   });
 
   it('stays Playing when seeking while playing', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     await engine.seekTo(20);
     expect(engine.getState()).toBe(State.Playing);
   });
 
   it('stays Paused when seeking while paused', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     await engine.pause();
     await engine.seekTo(20);
@@ -382,90 +386,76 @@ describe('seekTo (streaming path)', () => {
   });
 
   it('position reflects the new offset immediately after seek', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await engine.loadAndPlay(makeTrack());
     await engine.seekTo(90);
     expect(engine.getPosition()).toBeCloseTo(90, 5);
   });
 
   it('is a no-op when no track is loaded', async () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     await expect(engine.seekTo(10)).resolves.toBeUndefined();
     expect(engine.getState()).toBe(State.None);
   });
 });
 
-// ---------------------------------------------------------------------------
-// seekTo — buffer path
-// ---------------------------------------------------------------------------
-
 describe('seekTo (buffer fallback path)', () => {
-  beforeEach(() => setStreamerAvailable(false));
-
   it('creates a new AudioBufferSourceNode for the new offset', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine({ streamerAvailable: false });
     await engine.loadAndPlay(makeTrack());
-    clearCreatedSources();
+    context.createdSources.length = 0;
 
     await engine.seekTo(15);
 
-    const src = getCreatedSources()[0]!;
+    const src = context.createdSources[0]!;
     expect(src.start).toHaveBeenCalledWith(0, 15);
   });
 
   it('stays Paused when seeking while paused', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine({ streamerAvailable: false });
     await engine.loadAndPlay(makeTrack());
     await engine.pause();
-    clearCreatedSources();
+    context.createdSources.length = 0;
     await engine.seekTo(10);
     expect(engine.getState()).toBe(State.Paused);
     expect(engine.getPosition()).toBe(10);
   });
 });
 
-// ---------------------------------------------------------------------------
-// Natural track end
-// ---------------------------------------------------------------------------
-
 describe('onTrackEnded callback', () => {
   it('fires the callback when the streamer poller detects end', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     const cb = jest.fn();
     engine.onTrackEnded(cb);
 
     await engine.loadAndPlay(makeTrack(1, 30));
-    const ctx = getLastAudioContext()!;
-    ctx.advanceTime(30); // position >= duration - 0.1 → triggers poller
+    context.advanceTime(30);
     jest.advanceTimersByTime(250);
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(engine.getState()).toBe(State.Ended);
   });
 
-  it('does NOT fire callback when stop() was called before poller fires', async () => {
-    const engine = makeEngine();
+  it('does not fire callback when stop was called before poller fires', async () => {
+    const { engine, context } = makeEngine();
     const cb = jest.fn();
     engine.onTrackEnded(cb);
 
     await engine.loadAndPlay(makeTrack(1, 30));
-    await engine.stop(); // state → Stopped, poller cleared
-    const ctx = getLastAudioContext()!;
-    ctx.advanceTime(30);
+    await engine.stop();
+    context.advanceTime(30);
     jest.advanceTimersByTime(250);
 
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it('fires the callback when the buffer source ends naturally (buffer path)', async () => {
-    setStreamerAvailable(false);
-    const engine = makeEngine();
+  it('fires the callback when the buffer source ends naturally in buffer mode', async () => {
+    const { engine, context } = makeEngine({ streamerAvailable: false });
     const cb = jest.fn();
     engine.onTrackEnded(cb);
 
     await engine.loadAndPlay(makeTrack());
-    const sources = getCreatedSources();
-    const src = sources[sources.length - 1]!;
+    const src = context.createdSources[context.createdSources.length - 1]!;
     src.simulateEnded();
 
     expect(cb).toHaveBeenCalledTimes(1);
@@ -473,56 +463,43 @@ describe('onTrackEnded callback', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// getPosition
-// ---------------------------------------------------------------------------
-
 describe('getPosition', () => {
   it('returns 0 when not playing', () => {
-    const engine = makeEngine();
+    const { engine } = makeEngine();
     expect(engine.getPosition()).toBe(0);
   });
 
   it('tracks context.currentTime delta from playback start', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
-    const ctx = getLastAudioContext()!;
-    ctx.advanceTime(7);
+    context.advanceTime(7);
     expect(engine.getPosition()).toBeCloseTo(7, 5);
   });
 
   it('returns pausedPosition snapshot when paused', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
-    const ctx = getLastAudioContext()!;
-    ctx.advanceTime(12);
+    context.advanceTime(12);
     await engine.pause();
-    // Advance time further — should not affect position while paused
-    ctx.advanceTime(50);
+    context.advanceTime(50);
     expect(engine.getPosition()).toBeCloseTo(12, 5);
   });
 
   it('accounts for non-zero startOffset', async () => {
-    const engine = makeEngine();
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack(), 30);
     expect(engine.getPosition()).toBeCloseTo(30, 5);
-    const ctx = getLastAudioContext()!;
-    ctx.advanceTime(5);
+    context.advanceTime(5);
     expect(engine.getPosition()).toBeCloseTo(35, 5);
   });
 });
 
-// ---------------------------------------------------------------------------
-// destroy
-// ---------------------------------------------------------------------------
-
 describe('destroy', () => {
-  it('closes the AudioContext and resets state', async () => {
-    const engine = makeEngine();
+  it('closes the audio context and resets state', async () => {
+    const { engine, context } = makeEngine();
     await engine.loadAndPlay(makeTrack());
-    const ctx = getLastAudioContext()!;
     await engine.destroy();
-    expect(ctx.state).toBe('closed');
+    expect(context.state).toBe('closed');
     expect(engine.getState()).toBe(State.None);
     expect(engine.getDuration()).toBe(0);
     expect(engine.getPosition()).toBe(0);

--- a/src/audioContext.ts
+++ b/src/audioContext.ts
@@ -1,0 +1,39 @@
+import {
+  AudioContext,
+  decodeAudioData,
+  type AudioBufferSourceNode,
+  type GainNode,
+  type AudioBuffer,
+  type StreamerNode,
+} from 'react-native-audio-api';
+
+type AudioDestination = AudioContext['destination'];
+
+export interface PlaybackAudioContext {
+  readonly state: 'running' | 'suspended' | 'closed';
+  readonly currentTime: number;
+  readonly destination: AudioDestination;
+  createGain(): GainNode;
+  createBufferSource(): AudioBufferSourceNode;
+  createStreamer(): StreamerNode | null;
+  suspend(): boolean | Promise<boolean> | Promise<void>;
+  resume(): boolean | Promise<boolean> | Promise<void>;
+  close(): void | Promise<void>;
+}
+
+export interface PlaybackAudioApi {
+  createContext(): PlaybackAudioContext;
+  decode(url: string): Promise<AudioBuffer> | AudioBuffer;
+}
+
+export type {
+  AudioBuffer,
+  AudioBufferSourceNode,
+  GainNode,
+  StreamerNode,
+};
+
+export const playbackAudioApi: PlaybackAudioApi = {
+  createContext: () => new AudioContext(),
+  decode: (url) => decodeAudioData(url),
+};


### PR DESCRIPTION
## Summary
- introduce a thin `PlaybackAudioApi` / `PlaybackAudioContext` seam for the subset of audio APIs `PlaybackEngine` actually uses
- inject that seam into `PlaybackEngine` while keeping the default implementation backed by `react-native-audio-api`
- replace the hand-rolled module mock in `PlaybackEngine` tests with focused test doubles built against the smaller interface

## Testing
- npm test -- --runInBand

Closes #37