### PR TITLE
refactor: use Control enum in notification bridge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "prettier": "^3.2.5",
         "react": "^19.2.4",
         "react-native": "^0.84.1",
-        "react-native-audio-api": "^0.11.6",
+        "react-native-audio-api": "^0.11.7",
         "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
         "tsup": "^8.5.1",
@@ -29,7 +29,7 @@
         "@expo/config-plugins": ">=8.0.0",
         "react": ">=18.0.0",
         "react-native": ">=0.73.0",
-        "react-native-audio-api": ">=0.11.0"
+        "react-native-audio-api": ">=0.11.7"
       },
       "peerDependenciesMeta": {
         "@expo/config-plugins": {
@@ -11522,9 +11522,9 @@
       }
     },
     "node_modules/react-native-audio-api": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/react-native-audio-api/-/react-native-audio-api-0.11.6.tgz",
-      "integrity": "sha512-8hMO9Z1PW984KiEyvjbJYbgxEHEwa8sCwCGikfcxmsxr9AMWdmfHsF5TEHrlzMW6Rrt0qgGZpQAHCZgrdlN7cA==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/react-native-audio-api/-/react-native-audio-api-0.11.7.tgz",
+      "integrity": "sha512-2oIoP77Tn2nlouRVfEC3bAsuSyKU6xhGNkSnVXTLLQQZslEDoYX2cN9pVRZoWOqhFrLT8q4IZI9HaFgYL13L1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@expo/config-plugins": ">=8.0.0",
     "react": ">=18.0.0",
     "react-native": ">=0.73.0",
-    "react-native-audio-api": ">=0.11.0"
+    "react-native-audio-api": ">=0.11.7"
   },
   "peerDependenciesMeta": {
     "@expo/config-plugins": {
@@ -65,7 +65,7 @@
     "prettier": "^3.2.5",
     "react": "^19.2.4",
     "react-native": "^0.84.1",
-    "react-native-audio-api": "^0.11.6",
+    "react-native-audio-api": "^0.11.7",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "tsup": "^8.5.1",

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -11,17 +11,6 @@ import { emitter } from './EventEmitter';
  */
 
 type RNAPSubscription = { remove: () => void };
-type PlaybackControlName = Parameters<typeof PlaybackNotificationManager.enableControl>[0];
-
-const CONTROL_TO_RNAP_CONTROL: Record<Control, PlaybackControlName> = {
-  [Control.Play]: 'play',
-  [Control.Pause]: 'pause',
-  [Control.NextTrack]: 'nextTrack',
-  [Control.PreviousTrack]: 'previousTrack',
-  [Control.SkipForward]: 'skipForward',
-  [Control.SkipBackward]: 'skipBackward',
-  [Control.SeekTo]: 'seekTo',
-};
 
 export class NotificationBridge {
   private subscriptions: RNAPSubscription[] = [];
@@ -31,7 +20,7 @@ export class NotificationBridge {
    * Used by setup() to skip enableControl calls for controls that haven't changed,
    * avoiding unnecessary async work when updateOptions() is called more than once.
    */
-  private appliedControls: Map<PlaybackControlName, boolean> = new Map();
+  private appliedControls: Map<string, boolean> = new Map();
 
   // ---------------------------------------------------------------------------
   // Setup / teardown
@@ -41,23 +30,22 @@ export class NotificationBridge {
     this.teardown();
 
     // Enable only the requested controls; disable everything else.
-    // Use the public Control enum as the source of truth, then map to RNAP's
-    // concrete control names at the bridge boundary.
+    // Use the public Control enum as the single source of truth for supported
+    // notification controls so the bridge stays aligned with library API.
     // Only controls whose enabled/disabled state has changed since the last
     // setup() call are sent — this avoids redundant async work when
     // updateOptions() is called more than once (e.g. per-track control changes).
-    const enabledControls = new Set(controls.map(control => CONTROL_TO_RNAP_CONTROL[control]));
-    const allRNAPControls = Object.values(CONTROL_TO_RNAP_CONTROL);
+    const allRNAPControls = Object.values(Control);
     const changed = allRNAPControls.filter(control => {
-      const isEnabled = enabledControls.has(control);
+      const isEnabled = controls.includes(control);
       return this.appliedControls.get(control) !== isEnabled;
     });
 
     await Promise.all(
       changed.map(control => {
-        const isEnabled = enabledControls.has(control);
+        const isEnabled = controls.includes(control);
         this.appliedControls.set(control, isEnabled);
-        return PlaybackNotificationManager.enableControl(control, isEnabled);
+        return PlaybackNotificationManager.enableControl(control as Parameters<typeof PlaybackNotificationManager.enableControl>[0], isEnabled);
       })
     );
 

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -16,8 +16,8 @@ type PlaybackControlName = Parameters<typeof PlaybackNotificationManager.enableC
 const CONTROL_TO_RNAP_CONTROL: Record<Control, PlaybackControlName> = {
   [Control.Play]: 'play',
   [Control.Pause]: 'pause',
-  [Control.NextTrack]: 'next',
-  [Control.PreviousTrack]: 'previous',
+  [Control.NextTrack]: 'nextTrack',
+  [Control.PreviousTrack]: 'previousTrack',
   [Control.SkipForward]: 'skipForward',
   [Control.SkipBackward]: 'skipBackward',
   [Control.SeekTo]: 'seekTo',

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -30,20 +30,20 @@ export class NotificationBridge {
     this.teardown();
 
     // Enable only the requested controls; disable everything else.
-    // We iterate over all known RNAP control names to ensure unused ones are
-    // explicitly disabled (RNAP doesn't disable by default).
+    // Use the public Control enum as the single source of truth for supported
+    // notification controls so the bridge stays aligned with library API.
     // Only controls whose enabled/disabled state has changed since the last
     // setup() call are sent — this avoids redundant async work when
     // updateOptions() is called more than once (e.g. per-track control changes).
-    const allRNAPControls = ['play', 'pause', 'next', 'previous', 'skipForward', 'skipBackward', 'seekTo'] as const;
+    const allRNAPControls = Object.values(Control);
     const changed = allRNAPControls.filter(control => {
-      const isEnabled = (controls as string[]).includes(control);
+      const isEnabled = controls.includes(control);
       return this.appliedControls.get(control) !== isEnabled;
     });
 
     await Promise.all(
       changed.map(control => {
-        const isEnabled = (controls as string[]).includes(control);
+        const isEnabled = controls.includes(control);
         this.appliedControls.set(control, isEnabled);
         return PlaybackNotificationManager.enableControl(control, isEnabled);
       })

--- a/src/NotificationBridge.ts
+++ b/src/NotificationBridge.ts
@@ -11,6 +11,17 @@ import { emitter } from './EventEmitter';
  */
 
 type RNAPSubscription = { remove: () => void };
+type PlaybackControlName = Parameters<typeof PlaybackNotificationManager.enableControl>[0];
+
+const CONTROL_TO_RNAP_CONTROL: Record<Control, PlaybackControlName> = {
+  [Control.Play]: 'play',
+  [Control.Pause]: 'pause',
+  [Control.NextTrack]: 'next',
+  [Control.PreviousTrack]: 'previous',
+  [Control.SkipForward]: 'skipForward',
+  [Control.SkipBackward]: 'skipBackward',
+  [Control.SeekTo]: 'seekTo',
+};
 
 export class NotificationBridge {
   private subscriptions: RNAPSubscription[] = [];
@@ -20,7 +31,7 @@ export class NotificationBridge {
    * Used by setup() to skip enableControl calls for controls that haven't changed,
    * avoiding unnecessary async work when updateOptions() is called more than once.
    */
-  private appliedControls: Map<string, boolean> = new Map();
+  private appliedControls: Map<PlaybackControlName, boolean> = new Map();
 
   // ---------------------------------------------------------------------------
   // Setup / teardown
@@ -30,20 +41,21 @@ export class NotificationBridge {
     this.teardown();
 
     // Enable only the requested controls; disable everything else.
-    // Use the public Control enum as the single source of truth for supported
-    // notification controls so the bridge stays aligned with library API.
+    // Use the public Control enum as the source of truth, then map to RNAP's
+    // concrete control names at the bridge boundary.
     // Only controls whose enabled/disabled state has changed since the last
     // setup() call are sent — this avoids redundant async work when
     // updateOptions() is called more than once (e.g. per-track control changes).
-    const allRNAPControls = Object.values(Control);
+    const enabledControls = new Set(controls.map(control => CONTROL_TO_RNAP_CONTROL[control]));
+    const allRNAPControls = Object.values(CONTROL_TO_RNAP_CONTROL);
     const changed = allRNAPControls.filter(control => {
-      const isEnabled = controls.includes(control);
+      const isEnabled = enabledControls.has(control);
       return this.appliedControls.get(control) !== isEnabled;
     });
 
     await Promise.all(
       changed.map(control => {
-        const isEnabled = controls.includes(control);
+        const isEnabled = enabledControls.has(control);
         this.appliedControls.set(control, isEnabled);
         return PlaybackNotificationManager.enableControl(control, isEnabled);
       })


### PR DESCRIPTION
## Summary
- use `Object.values(Control)` in `NotificationBridge`
- remove the duplicated hardcoded list of notification control labels
- use the public `Control` enum as the source of truth for supported controls

## Why
The bridge should not maintain its own separate list of control names when the library already exposes `Control` for that purpose.

Using the enum directly keeps the notification bridge aligned with the public API and avoids drift between:
- the exported control set
- the control labels used when enabling/disabling notification controls

## Changes
- replace the local `allRNAPControls` string array with `Object.values(Control)`
- simplify `includes()` checks to use the typed `controls` array directly

## Testing
- configuration/code cleanup only
